### PR TITLE
feat: create environments

### DIFF
--- a/src/sempy_labs/environments/__init__.py
+++ b/src/sempy_labs/environments/__init__.py
@@ -1,0 +1,3 @@
+from ._environments import create_environment
+
+__all__ = [create_environment]

--- a/src/sempy_labs/environments/_environments.py
+++ b/src/sempy_labs/environments/_environments.py
@@ -1,0 +1,50 @@
+
+import sempy.fabric as fabric
+import json
+import sempy_labs._icons as icons
+def create_environment(workspace_name: str, environment_name: str, environment_description: str = None):
+    """
+    Creates a new environment in the specified workspace using the Fabric API.
+
+    This function sends a POST request to the Fabric API to create a new environment
+    within a specified workspace. The environment's name is provided, and an optional
+    description of the environment can be added.
+
+    Args:
+        workspace_name (str): The name of the workspace in which the environment is created.
+        environment_name (str): The display name of the new environment.
+        environment_description (str, optional): An optional description for the environment. Defaults to None.
+
+    Example:
+        create_environment("My Workspace", "My Environment", "Test environment")
+
+    Docs: https://learn.microsoft.com/en-us/rest/api/fabric/environment/items/create-environment?tabs=HTTP
+    """
+
+    # Resolve the workspace ID based on the workspace name
+    workspace_id = fabric.resolve_workspace_id(workspace_name)
+    client = fabric.FabricRestClient()
+
+    # Prepare the configuration for the new environment
+    environment_conf = {
+        "displayName": environment_name
+    }
+
+    if environment_description:
+        environment_conf = environment_conf | {"description": environment_description}
+
+    try:
+        # Send a POST request to the Fabric API to create the environmen
+        response = client.post(f"https://api.fabric.microsoft.com/v1/workspaces/{workspace_id}/environments/",
+                            data=json.dumps(environment_conf))
+
+        if response.status_code == 201:
+            print(f"{icons.green_dot} The environment '{environment_name}' was created in the '{workspace_name}' workspace")
+        else:
+            print(response.status_code)
+    except Exception as e:
+        raise ValueError(
+            f"{icons.red_dot} Failed to create an environment for the '{workspace_name}' workspace."
+        ) from e
+
+

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -1,0 +1,93 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import json
+import sempy_labs._icons as icons
+from sempy_labs.environments import create_environment
+
+
+class TestCreateEnvironment(unittest.TestCase):
+
+    @patch('sempy.fabric.FabricRestClient')
+    @patch('sempy.fabric.resolve_workspace_id')
+    def test_create_environment_success_with_description(self, mock_resolve_workspace_id, mock_fabric_client):
+        """
+        Test case for successfully creating an environment with a description.
+        """
+        # Mocking the workspace ID resolution
+        mock_resolve_workspace_id.return_value = "test_workspace_id"
+
+        # Mocking the FabricRestClient response
+        mock_client_instance = MagicMock()
+        mock_fabric_client.return_value = mock_client_instance
+        mock_client_instance.post.return_value.status_code = 201
+
+        # Call the function with description
+        with patch('builtins.print') as mock_print:
+            create_environment("Test Workspace", "Test Environment", "This is a test description")
+            mock_print.assert_any_call(f"{icons.green_dot} The environment 'Test Environment' was created in the 'Test Workspace' workspace")
+
+        # Assertions
+        mock_resolve_workspace_id.assert_called_once_with("Test Workspace")
+        mock_client_instance.post.assert_called_once_with(
+            "https://api.fabric.microsoft.com/v1/workspaces/test_workspace_id/environments/",
+            data=json.dumps({
+                "displayName": "Test Environment",
+                "description": "This is a test description"
+            })
+        )
+
+    @patch('sempy.fabric.FabricRestClient')
+    @patch('sempy.fabric.resolve_workspace_id')
+    def test_create_environment_success_without_description(self, mock_resolve_workspace_id, mock_fabric_client):
+        """
+        Test case for successfully creating an environment without a description.
+        """
+        # Mocking the workspace ID resolution
+        mock_resolve_workspace_id.return_value = "test_workspace_id"
+
+        # Mocking the FabricRestClient response
+        mock_client_instance = MagicMock()
+        mock_fabric_client.return_value = mock_client_instance
+        mock_client_instance.post.return_value.status_code = 201
+
+        # Call the function without description
+        with patch('builtins.print') as mock_print:
+            create_environment("Test Workspace", "Test Environment")
+            mock_print.assert_any_call(f"{icons.green_dot} The environment 'Test Environment' was created in the 'Test Workspace' workspace")
+
+        # Assertions
+        mock_resolve_workspace_id.assert_called_once_with("Test Workspace")
+        mock_client_instance.post.assert_called_once_with(
+            "https://api.fabric.microsoft.com/v1/workspaces/test_workspace_id/environments/",
+            data=json.dumps({
+                "displayName": "Test Environment"
+            })
+        )
+
+    @patch('sempy.fabric.FabricRestClient')
+    @patch('sempy.fabric.resolve_workspace_id')
+    def test_create_environment_failure(self, mock_resolve_workspace_id, mock_fabric_client):
+        """
+        Test case for failing to create an environment with a non-201 status code.
+        """
+        # Mocking the workspace ID resolution
+        mock_resolve_workspace_id.return_value = "test_workspace_id"
+
+        # Mocking the FabricRestClient response
+        mock_client_instance = MagicMock()
+        mock_fabric_client.return_value = mock_client_instance
+        mock_client_instance.post.return_value.status_code = 400
+
+        # Capture printed output
+        with patch('builtins.print') as mock_print:
+            create_environment("Test Workspace", "Test Environment")
+            mock_print.assert_any_call(400)
+
+        mock_resolve_workspace_id.assert_called_once_with("Test Workspace")
+        mock_client_instance.post.assert_called_once_with(
+            "https://api.fabric.microsoft.com/v1/workspaces/test_workspace_id/environments/",
+            data=json.dumps({"displayName": "Test Environment"})
+        )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Overview
This PR introduces a way to create environments for a specific workspace using the Fabric API: https://learn.microsoft.com/en-us/rest/api/fabric/environment/items/create-environment

# Details
```python
def create_environment(workspace_name: str, environment_name: str, environment_description: str = None):
```

Maybe this is not the right library to add the functionality, but I was unable to find the `semantic-link-sempy` library.

I have more functionalities I can contribute with, but I want to get some feedback on this initially.

Please let me know if you use any format or linting rules.
