### PR TITLE
feat: list environments

### DIFF
--- a/src/sempy_labs/environments/__init__.py
+++ b/src/sempy_labs/environments/__init__.py
@@ -1,0 +1,3 @@
+from ._environments import list_environments
+
+__all__ = [list_environments]

--- a/src/sempy_labs/environments/_environments.py
+++ b/src/sempy_labs/environments/_environments.py
@@ -1,0 +1,46 @@
+import requests
+import json
+import sempy.fabric as fabric
+from sempy.fabric.exceptions import FabricHTTPException
+import sempy_labs._icons as icons
+
+def list_environments(workspace_name: str) -> dict:
+    """
+        Retrieves the list of environments for a given workspace using the Fabric API.
+
+        This function sends a GET request to the Fabric API to fetch all environments
+        within the specified workspace. It returns a dictionary where each environments's
+        display name is the key and the corresponding environments ID is the value.
+
+        Args:
+            workspace_name (str): The name of the workspace to retrieve environments from.
+
+        Returns:
+            dict: A dictionary with environments display names as keys and environments IDs as values.
+
+        Example:
+            get_environments("Some Workspace")
+
+        Docs: https://learn.microsoft.com/en-us/rest/api/fabric/environment/items/list-environments?tabs=HTTP
+    """
+
+    workspace_id = fabric.resolve_workspace_id(workspace_name)
+    client = fabric.FabricRestClient()
+
+    try:
+        response = client.get(f"https://api.fabric.microsoft.com/v1/workspaces/{workspace_id}/environments")
+
+        if response.status_code != 200:
+            raise FabricHTTPException(response)
+    except FabricHTTPException as e:
+        raise e
+    except Exception as e:
+        raise ValueError(
+            f"{icons.red_dot} Failed to list environments for the '{workspace_name}' workspace."
+        ) from e
+
+    env_json = json.loads(response.content)
+
+    environments_dict = {workspace['displayName']: workspace['id'] for workspace in env_json.get('value', [])}
+
+    return environments_dict

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -1,0 +1,83 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from sempy_labs.environments import list_environments
+from sempy.fabric.exceptions import FabricHTTPException
+import json
+
+class TestListEnvironments(unittest.TestCase):
+    @patch('sempy.fabric.FabricRestClient')
+    @patch('sempy.fabric.resolve_workspace_id')
+    def test_list_environments_success(self, mock_resolve_workspace_id, mock_fabric_client):
+        """
+        Test successful environment listing from the Fabric API.
+        """
+        # Mock the workspace_id to be returned by resolve_workspace_id
+        mock_resolve_workspace_id.return_value = 'workspace-id-123'
+
+        # Mock a successful response from the Fabric API
+        mock_client_instance = MagicMock()
+        mock_fabric_client.return_value = mock_client_instance
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = json.dumps({
+            "value": [
+                {"displayName": "Environment 1", "id": "env-1-id"},
+                {"displayName": "Environment 2", "id": "env-2-id"}
+            ]
+        })
+        mock_client_instance.get.return_value = mock_response
+
+        # Call the function and assert the result
+        result = list_environments("test_workspace")
+        expected_result = {
+            "Environment 1": "env-1-id",
+            "Environment 2": "env-2-id"
+        }
+        self.assertEqual(result, expected_result)
+
+        # Assert that resolve_workspace_id and the Fabric client were called
+        mock_resolve_workspace_id.assert_called_once_with("test_workspace")
+        mock_client_instance.get.assert_called_once_with(
+            "https://api.fabric.microsoft.com/v1/workspaces/workspace-id-123/environments"
+        )
+
+    @patch('sempy.fabric.FabricRestClient')
+    @patch('sempy.fabric.resolve_workspace_id')
+    def test_list_environments_non_200_response(self, mock_resolve_workspace_id, mock_fabric_client):
+        """
+        Test handling of a non-200 status code from the Fabric API.
+        """
+        mock_resolve_workspace_id.return_value = 'workspace-id-123'
+
+        # Mock a non-200 response
+        mock_client_instance = MagicMock()
+        mock_fabric_client.return_value = mock_client_instance
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_client_instance.get.return_value = mock_response
+
+        with self.assertRaises(FabricHTTPException) as context:
+            list_environments("test_workspace")
+
+    @patch('sempy.fabric.FabricRestClient')
+    @patch('sempy.fabric.resolve_workspace_id')
+    def test_list_environments_exception_handling(self, mock_resolve_workspace_id, mock_fabric_client):
+        """
+        Test exception handling when an error occurs during the API request.
+        """
+        mock_resolve_workspace_id.return_value = 'workspace-id-123'
+
+        # Mock an exception being raised
+        mock_client_instance = MagicMock()
+        mock_fabric_client.return_value = mock_client_instance
+        mock_client_instance.get.side_effect = Exception("Something went wrong")
+
+        with self.assertRaises(ValueError) as context:
+            list_environments("test_workspace")
+
+        # Assert that the raised ValueError contains the correct message
+        self.assertIn("Failed to list environments", str(context.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Overview
This PR introduces a way to list environments for a specific workspace using the Fabric API: https://learn.microsoft.com/en-us/rest/api/fabric/environment/items/list-environments?tabs=HTTP

# Details
```python
def list_environments(workspace_name: str) -> dict:
```

Maybe this is not the right library to add the functionality, but I was unable to find the `semantic-link-sempy` library.

Please let me know if you use any format or linting rules.
