### PR TITLE
ecotte/authenticationModule

### DIFF
--- a/src/sempy_labs/__init__.py
+++ b/src/sempy_labs/__init__.py
@@ -1,6 +1,6 @@
 from sempy_labs._authentication import (
     ServicePrincipalTokenProvider,
-    ServicePrincipalTokenProviderWithKeyVault,
+    ServicePrincipalTokenProviderFromKeyVault,
 )
 from sempy_labs._mirrored_databases import (
     get_mirrored_database_definition,
@@ -430,5 +430,5 @@ __all__ = [
     "get_tables_mirroring_status",
     "list_upstream_dataflows",
     "ServicePrincipalTokenProvider",
-    "ServicePrincipalTokenProviderWithKeyVault",
+    "ServicePrincipalTokenProviderFromKeyVault",
 ]

--- a/src/sempy_labs/__init__.py
+++ b/src/sempy_labs/__init__.py
@@ -1,3 +1,7 @@
+from sempy_labs._authentication import (
+    ServicePrincipalTokenProvider,
+    ServicePrincipalTokenProviderWithKeyVault,
+)
 from sempy_labs._mirrored_databases import (
     get_mirrored_database_definition,
     get_mirroring_status,
@@ -425,4 +429,6 @@ __all__ = [
     "update_mirrored_database_definition",
     "get_tables_mirroring_status",
     "list_upstream_dataflows",
+    "ServicePrincipalTokenProvider",
+    "ServicePrincipalTokenProviderWithKeyVault",
 ]

--- a/src/sempy_labs/_authentication.py
+++ b/src/sempy_labs/_authentication.py
@@ -3,24 +3,21 @@ from sempy.fabric._token_provider import TokenProvider
 import notebookutils
 from azure.identity import ClientSecretCredential
 
-class ServicePrincipalTokenProvider(TokenProvider):   
+
+class ServicePrincipalTokenProvider(TokenProvider):
     """
     Implementation of the sempy.fabric.TokenProvider to be used with Service Principal.
 
     For more information on Service Principal check `Application and service principal objects in Microsoft Entra ID <https://learn.microsoft.com/en-us/entra/identity-platform/app-objects-and-service-principals?tabs=browser#service-principal-object>`_
-
     """
 
-    def __init__(self,credential:ClientSecretCredential):
-
+    def __init__(self, credential: ClientSecretCredential):
         self.credential = credential
-    
+
     @classmethod
-    def with_aad_application_key_authentication(cls, 
-        tenant_id:str,
-        client_id:str,
-        client_secret:str
-        ):
+    def with_aad_application_key_authentication(
+        cls, tenant_id: str, client_id: str, client_secret: str
+    ):
         """
         Create the ServicePrincipalTokenProvider with the Service Principal information.
 
@@ -40,20 +37,20 @@ class ServicePrincipalTokenProvider(TokenProvider):
         sempy.fabric.TokenProvider
             Token provider to be used with FabricRestClient or PowerBIRestClient.
         """
-
         credential = ClientSecretCredential(
             tenant_id=tenant_id, client_id=client_id, client_secret=client_secret
-        ) 
+        )
 
         return cls(credential)
 
     @classmethod
-    def with_azure_key_vault(cls, 
-        key_vault_uri:str, 
-        key_vault_tenant_id:str,
-        key_vault_client_id:str,
-        key_vault_client_secret:str
-        ):
+    def with_azure_key_vault(
+        cls,
+        key_vault_uri: str,
+        key_vault_tenant_id: str,
+        key_vault_client_id: str,
+        key_vault_client_secret: str,
+    ):
         """
         Create the ServicePrincipalTokenProvider providing the information with the Service Principal information.
 
@@ -61,7 +58,7 @@ class ServicePrincipalTokenProvider(TokenProvider):
 
         Parameters
         ----------
-        key_vault_uri : str 
+        key_vault_uri : str
             Azure Key Vault URI.
         key_vault_tenant_id : str,
             Name of the secret in the Key Vault with the Fabric Tenant ID.
@@ -69,20 +66,25 @@ class ServicePrincipalTokenProvider(TokenProvider):
             Name of the secret in the Key Vault with the Service Principal Client ID.
         key_vault_client_secret : str
             Name of the secret in the Key Vault with the Service Principal Client Secret.
-        
+
         Returns
         -------
         sempy.fabric.TokenProvider
             Token provider to be used with FabricRestClient or PowerBIRestClient.
         """
-
-        tenant_id = notebookutils.credentials.getSecret(key_vault_uri, key_vault_tenant_id)
-        client_id = notebookutils.credentials.getSecret(key_vault_uri, key_vault_client_id)
-        client_secret = notebookutils.credentials.getSecret(key_vault_uri, key_vault_client_secret)
+        tenant_id = notebookutils.credentials.getSecret(
+            key_vault_uri, key_vault_tenant_id
+        )
+        client_id = notebookutils.credentials.getSecret(
+            key_vault_uri, key_vault_client_id
+        )
+        client_secret = notebookutils.credentials.getSecret(
+            key_vault_uri, key_vault_client_secret
+        )
 
         credential = ClientSecretCredential(
             tenant_id=tenant_id, client_id=client_id, client_secret=client_secret
-        ) 
+        )
 
         return cls(credential)
 
@@ -94,7 +96,9 @@ class ServicePrincipalTokenProvider(TokenProvider):
             Literal if it's for PBI/Fabric API call or OneLake/Storage Account call.
         """
         if audience == "pbi":
-            return self.credential.get_token("https://analysis.windows.net/powerbi/api/.default").token
+            return self.credential.get_token(
+                "https://analysis.windows.net/powerbi/api/.default"
+            ).token
         elif audience == "storage":
             return self.credential.get_token("https://storage.azure.com/.default").token
         else:

--- a/src/sempy_labs/_authentication.py
+++ b/src/sempy_labs/_authentication.py
@@ -1,0 +1,48 @@
+from typing import Literal
+from sempy.fabric._token_provider import TokenProvider
+import notebookutils
+from azure.identity import ClientSecretCredential
+
+class ServicePrincipalTokenProviderWithKeyVault(TokenProvider):   
+
+    def __init__(self, key_vault_uri, key_vault_tenant_id, key_vault_client_id, key_vault_client_secret):
+        self.key_vault_uri = key_vault_uri
+        self.key_vault_tenant_id = key_vault_tenant_id
+        self.key_vault_client_id = key_vault_client_id
+        self.key_vault_client_secret = key_vault_client_secret
+
+        self.tenant_id = notebookutils.credentials.getSecret(key_vault_uri, key_vault_tenant_id)
+        self.client_id = notebookutils.credentials.getSecret(key_vault_uri, key_vault_client_id)
+        self.client_secret = notebookutils.credentials.getSecret(key_vault_uri, key_vault_client_secret)
+
+        self.credential = ClientSecretCredential(
+            tenant_id=self.tenant_id, client_id=self.client_id, client_secret=self.client_secret
+        ) 
+
+    def __call__(self, audience: Literal["pbi", "storage"] = "pbi") -> str:
+        if audience == "pbi":
+            return self.credential.get_token("https://analysis.windows.net/powerbi/api/.default").token
+        elif audience == "storage":
+            return self.credential.get_token("https://storage.azure.com/.default").token
+        else:
+            raise NotImplementedError
+
+class ServicePrincipalTokenProvider(TokenProvider):   
+
+    def __init__(self, tenant_id, client_id, client_secret):
+
+        self.tenant_id = tenant_id
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+        self.credential = ClientSecretCredential(
+            tenant_id=self.tenant_id, client_id=self.client_id, client_secret=self.client_secret
+        ) 
+
+    def __call__(self, audience: Literal["pbi", "storage"] = "pbi") -> str:
+        if audience == "pbi":
+            return self.credential.get_token("https://analysis.windows.net/powerbi/api/.default").token
+        elif audience == "storage":
+            return self.credential.get_token("https://storage.azure.com/.default").token
+        else:
+            raise NotImplementedError

--- a/src/sempy_labs/_authentication.py
+++ b/src/sempy_labs/_authentication.py
@@ -3,38 +3,62 @@ from sempy.fabric._token_provider import TokenProvider
 import notebookutils
 from azure.identity import ClientSecretCredential
 
-class ServicePrincipalTokenProviderFromKeyVault(TokenProvider):   
+class ServicePrincipalTokenProvider(TokenProvider):   
     """
-    Implementation of the sempy.fabric.TokenProvider to be used with Service Principal providing the Azure Key Vault information.
+    Implementation of the sempy.fabric.TokenProvider to be used with Service Principal.
 
-    For more information on Serice Principal check `Application and service principal objects in Microsoft Entra ID <https://learn.microsoft.com/en-us/entra/identity-platform/app-objects-and-service-principals?tabs=browser#service-principal-object>`_
+    For more information on Service Principal check `Application and service principal objects in Microsoft Entra ID <https://learn.microsoft.com/en-us/entra/identity-platform/app-objects-and-service-principals?tabs=browser#service-principal-object>`_
 
-    For more information on Azure Key Vault check `About Azure Key Vault <https://learn.microsoft.com/en-us/azure/key-vault/general/overview>`_
+    """
 
-    Parameters
-    ----------
-    key_vault_uri : str 
-        Azure Key Vault URI.
-    key_vault_tenant_id : str,
-        Name of the secret in the Key Vault with the Fabric Tenant ID.
-    key_vault_client_id : str,
-        Name of the secret in the Key Vault with the Service Principal Client ID.
-    key_vault_client_secret : str
-        Name of the secret in the Key Vault with the Service Principal Client Secret.
+    def __init__(self,credential:ClientSecretCredential):
+
+        self.credential = credential
     
-    Returns
-    -------
-    sempy.fabric.TokenProvider
-        Token provider to be used with FabricRestClient or PowerBIRestClient.
-    """
+    @classmethod
+    def with_aad_application_key_authentication(cls, 
+        tenant_id:str,
+        client_id:str,
+        client_secret:str
+        ):
+        """
+        Create the ServicePrincipalTokenProvider with the Service Principal information.
 
-    def __init__(self, 
+        ***USE THIS ONE ONLY FOR TEST PURPOSE. FOR PRODUCTION WE RECOMMEND CALLING ServicePrincipalTokenProvider.from_key_vault()***
+
+        Parameters
+        ----------
+        tenant_id : str
+            Fabric Tenant ID.
+        client_id : str
+            Service Principal App Client ID.
+        client_secret : str
+            Service Principal Secret.
+
+        Returns
+        -------
+        sempy.fabric.TokenProvider
+            Token provider to be used with FabricRestClient or PowerBIRestClient.
+        """
+
+        credential = ClientSecretCredential(
+            tenant_id=tenant_id, client_id=client_id, client_secret=client_secret
+        ) 
+
+        return cls(credential)
+
+    @classmethod
+    def with_azure_key_vault(cls, 
         key_vault_uri:str, 
         key_vault_tenant_id:str,
         key_vault_client_id:str,
         key_vault_client_secret:str
         ):
         """
+        Create the ServicePrincipalTokenProvider providing the information with the Service Principal information.
+
+        For more information on Azure Key Vault check `About Azure Key Vault <https://learn.microsoft.com/en-us/azure/key-vault/general/overview>`_
+
         Parameters
         ----------
         key_vault_uri : str 
@@ -52,83 +76,15 @@ class ServicePrincipalTokenProviderFromKeyVault(TokenProvider):
             Token provider to be used with FabricRestClient or PowerBIRestClient.
         """
 
-        self.key_vault_uri = key_vault_uri
-        self.key_vault_tenant_id = key_vault_tenant_id
-        self.key_vault_client_id = key_vault_client_id
-        self.key_vault_client_secret = key_vault_client_secret
+        tenant_id = notebookutils.credentials.getSecret(key_vault_uri, key_vault_tenant_id)
+        client_id = notebookutils.credentials.getSecret(key_vault_uri, key_vault_client_id)
+        client_secret = notebookutils.credentials.getSecret(key_vault_uri, key_vault_client_secret)
 
-        self.tenant_id = notebookutils.credentials.getSecret(key_vault_uri, key_vault_tenant_id)
-        self.client_id = notebookutils.credentials.getSecret(key_vault_uri, key_vault_client_id)
-        self.client_secret = notebookutils.credentials.getSecret(key_vault_uri, key_vault_client_secret)
-
-        self.credential = ClientSecretCredential(
-            tenant_id=self.tenant_id, client_id=self.client_id, client_secret=self.client_secret
+        credential = ClientSecretCredential(
+            tenant_id=tenant_id, client_id=client_id, client_secret=client_secret
         ) 
 
-    def __call__(self, audience: Literal["pbi", "storage"] = "pbi") -> str:
-        """
-        Parameters
-        ----------
-        audience : Literal["pbi", "storage"] = "pbi") -> str
-            Literal if it's for PBI/Fabric API call or OneLake/Storage Account call.
-        """
-        if audience == "pbi":
-            return self.credential.get_token("https://analysis.windows.net/powerbi/api/.default").token
-        elif audience == "storage":
-            return self.credential.get_token("https://storage.azure.com/.default").token
-        else:
-            raise NotImplementedError
-
-class ServicePrincipalTokenProvider(TokenProvider):   
-    """
-    Implementation of the sempy.fabric.TokenProvider to be used with Service Principal providing the SP properties.
-
-    For more information on Serice Principal check `Application and service principal objects in Microsoft Entra ID <https://learn.microsoft.com/en-us/entra/identity-platform/app-objects-and-service-principals?tabs=browser#service-principal-object>`_
-
-    ***USE THIS ONE ONLY FOR TEST PURPOSE. FOR PRODUCTION WE RECOMEND THE ServicePrincipalTokenProviderWithKeyVault***
-
-    Parameters
-    ----------
-    tenant_id : str
-        Fabric Tenant ID.
-    client_id : str
-        Service Principal App Client ID.
-    client_secret : str
-        Service Principal Secret.
-
-    Returns
-    -------
-    sempy.fabric.TokenProvider
-        Token provider to be used with FabricRestClient or PowerBIRestClient.
-    """
-
-    def __init__(self, 
-        tenant_id:str,
-        client_id:str,
-        client_secret:str
-        ):
-        """
-        Parameters
-        ----------
-        tenant_id : str
-            Fabric Tenant ID.
-        client_id : str
-            Service Principal App Client ID.
-        client_secret : str
-            Service Principal Secret.
-
-        Returns
-        -------
-        sempy.fabric.TokenProvider
-            Token provider to be used with FabricRestClient or PowerBIRestClient.
-        """
-        self.tenant_id = tenant_id
-        self.client_id = client_id
-        self.client_secret = client_secret
-
-        self.credential = ClientSecretCredential(
-            tenant_id=self.tenant_id, client_id=self.client_id, client_secret=self.client_secret
-        ) 
+        return cls(credential)
 
     def __call__(self, audience: Literal["pbi", "storage"] = "pbi") -> str:
         """

--- a/src/sempy_labs/_authentication.py
+++ b/src/sempy_labs/_authentication.py
@@ -4,8 +4,45 @@ import notebookutils
 from azure.identity import ClientSecretCredential
 
 class ServicePrincipalTokenProviderWithKeyVault(TokenProvider):   
+    """
+    Implementation of the sempy.fabric.TokenProvider to be used with Service Principal providing the Azure Key Vault information.
 
-    def __init__(self, key_vault_uri, key_vault_tenant_id, key_vault_client_id, key_vault_client_secret):
+    For more information on Serice Principal check `Application and service principal objects in Microsoft Entra ID <https://learn.microsoft.com/en-us/entra/identity-platform/app-objects-and-service-principals?tabs=browser#service-principal-object>`_
+
+    For more information on Azure Key Vault check `About Azure Key Vault <https://learn.microsoft.com/en-us/azure/key-vault/general/overview>`_
+
+    Parameters
+    ----------
+    key_vault_uri : str 
+        Azure Key Vault URL.
+    key_vault_tenant_id:str,
+        Name of the secret in the Key Vault with the Fabric Tenant ID.
+    key_vault_client_id:str,
+        Name of the secret in the Key Vault with the SP Client ID.
+    key_vault_client_secret:str
+        Name of the secret in the Key Vault with the SP Client Secret.
+
+    """
+
+    def __init__(self, 
+        key_vault_uri:str, 
+        key_vault_tenant_id:str,
+        key_vault_client_id:str,
+        key_vault_client_secret:str
+        ):
+        """
+        Parameters
+        ----------
+        key_vault_uri : str 
+            Azure Key Vault URL.
+        key_vault_tenant_id:str,
+            Name of the secret in the Key Vault with the Fabric Tenant ID.
+        key_vault_client_id:str,
+            Name of the secret in the Key Vault with the SP Client ID.
+        key_vault_client_secret:str
+            Name of the secret in the Key Vault with the SP Client Secret.
+        """
+
         self.key_vault_uri = key_vault_uri
         self.key_vault_tenant_id = key_vault_tenant_id
         self.key_vault_client_id = key_vault_client_id
@@ -20,6 +57,12 @@ class ServicePrincipalTokenProviderWithKeyVault(TokenProvider):
         ) 
 
     def __call__(self, audience: Literal["pbi", "storage"] = "pbi") -> str:
+        """
+        Parameters
+        ----------
+        audience : Literal["pbi", "storage"] = "pbi") -> str
+            Literal if it's for PBI/Fabric API call or OneLake/Storage Account call.
+        """
         if audience == "pbi":
             return self.credential.get_token("https://analysis.windows.net/powerbi/api/.default").token
         elif audience == "storage":
@@ -28,9 +71,38 @@ class ServicePrincipalTokenProviderWithKeyVault(TokenProvider):
             raise NotImplementedError
 
 class ServicePrincipalTokenProvider(TokenProvider):   
+    """
+    Implementation of the sempy.fabric.TokenProvider to be used with Service Principal providing the SP properties.
 
-    def __init__(self, tenant_id, client_id, client_secret):
+    For more information on Serice Principal check `Application and service principal objects in Microsoft Entra ID <https://learn.microsoft.com/en-us/entra/identity-platform/app-objects-and-service-principals?tabs=browser#service-principal-object>`_
 
+    ***USE THIS ONE ONLY FOR TEST PURPOSE. FOR PRODUCTION WE RECOMEND THE ServicePrincipalTokenProviderWithKeyVault***
+
+    Parameters
+    ----------
+    tenant_id : str
+        Fabric Tenant ID.
+    client_id : str
+        Service Principal App Client ID.
+    client_secret : str
+        Service Principal Secret.
+    """
+
+    def __init__(self, 
+        tenant_id:str,
+        client_id:str,
+        client_secret:str
+        ):
+        """
+        Parameters
+        ----------
+        tenant_id : str
+            Fabric Tenant ID.
+        client_id : str
+            Service Principal App Client ID.
+        client_secret : str
+            Service Principal Secret.
+        """
         self.tenant_id = tenant_id
         self.client_id = client_id
         self.client_secret = client_secret
@@ -40,6 +112,12 @@ class ServicePrincipalTokenProvider(TokenProvider):
         ) 
 
     def __call__(self, audience: Literal["pbi", "storage"] = "pbi") -> str:
+        """
+        Parameters
+        ----------
+        audience : Literal["pbi", "storage"] = "pbi") -> str
+            Literal if it's for PBI/Fabric API call or OneLake/Storage Account call.
+        """
         if audience == "pbi":
             return self.credential.get_token("https://analysis.windows.net/powerbi/api/.default").token
         elif audience == "storage":

--- a/src/sempy_labs/_authentication.py
+++ b/src/sempy_labs/_authentication.py
@@ -3,7 +3,7 @@ from sempy.fabric._token_provider import TokenProvider
 import notebookutils
 from azure.identity import ClientSecretCredential
 
-class ServicePrincipalTokenProviderWithKeyVault(TokenProvider):   
+class ServicePrincipalTokenProviderFromKeyVault(TokenProvider):   
     """
     Implementation of the sempy.fabric.TokenProvider to be used with Service Principal providing the Azure Key Vault information.
 
@@ -14,14 +14,18 @@ class ServicePrincipalTokenProviderWithKeyVault(TokenProvider):
     Parameters
     ----------
     key_vault_uri : str 
-        Azure Key Vault URL.
-    key_vault_tenant_id:str,
+        Azure Key Vault URI.
+    key_vault_tenant_id : str,
         Name of the secret in the Key Vault with the Fabric Tenant ID.
-    key_vault_client_id:str,
-        Name of the secret in the Key Vault with the SP Client ID.
-    key_vault_client_secret:str
-        Name of the secret in the Key Vault with the SP Client Secret.
-
+    key_vault_client_id : str,
+        Name of the secret in the Key Vault with the Service Principal Client ID.
+    key_vault_client_secret : str
+        Name of the secret in the Key Vault with the Service Principal Client Secret.
+    
+    Returns
+    -------
+    sempy.fabric.TokenProvider
+        Token provider to be used with FabricRestClient or PowerBIRestClient.
     """
 
     def __init__(self, 
@@ -34,13 +38,18 @@ class ServicePrincipalTokenProviderWithKeyVault(TokenProvider):
         Parameters
         ----------
         key_vault_uri : str 
-            Azure Key Vault URL.
-        key_vault_tenant_id:str,
+            Azure Key Vault URI.
+        key_vault_tenant_id : str,
             Name of the secret in the Key Vault with the Fabric Tenant ID.
-        key_vault_client_id:str,
-            Name of the secret in the Key Vault with the SP Client ID.
-        key_vault_client_secret:str
-            Name of the secret in the Key Vault with the SP Client Secret.
+        key_vault_client_id : str,
+            Name of the secret in the Key Vault with the Service Principal Client ID.
+        key_vault_client_secret : str
+            Name of the secret in the Key Vault with the Service Principal Client Secret.
+        
+        Returns
+        -------
+        sempy.fabric.TokenProvider
+            Token provider to be used with FabricRestClient or PowerBIRestClient.
         """
 
         self.key_vault_uri = key_vault_uri
@@ -86,6 +95,11 @@ class ServicePrincipalTokenProvider(TokenProvider):
         Service Principal App Client ID.
     client_secret : str
         Service Principal Secret.
+
+    Returns
+    -------
+    sempy.fabric.TokenProvider
+        Token provider to be used with FabricRestClient or PowerBIRestClient.
     """
 
     def __init__(self, 
@@ -102,6 +116,11 @@ class ServicePrincipalTokenProvider(TokenProvider):
             Service Principal App Client ID.
         client_secret : str
             Service Principal Secret.
+
+        Returns
+        -------
+        sempy.fabric.TokenProvider
+            Token provider to be used with FabricRestClient or PowerBIRestClient.
         """
         self.tenant_id = tenant_id
         self.client_id = client_id

--- a/src/sempy_labs/tom/_model.py
+++ b/src/sempy_labs/tom/_model.py
@@ -4369,7 +4369,7 @@ class TOMWrapper:
         pandas.DataFrame
             A pandas dataframe showing the updated measure(s) and their new description(s).
         """
-        icons.sll_tags.append('GenerateMeasureDescriptions')
+        icons.sll_tags.append("GenerateMeasureDescriptions")
 
         df = pd.DataFrame(
             columns=["Table Name", "Measure Name", "Expression", "Description"]


### PR DESCRIPTION
Added the authentication Module for Service Principal API calls.

Objects added:

- ServicePrincipalTokenProviderWithKeyVault: Used to get the Token Provider with Key Vault information.
- ServicePrincipalTokenProvider: Used to get the Token Provider with direct Service Principal information. RECOMMENDED FOR TESTING PUPOSE ONLY.