### PR TITLE
Updated REGEX to match full column reference only for Unqualified Column checks.

### DIFF
--- a/src/sempy_labs/tom/_model.py
+++ b/src/sempy_labs/tom/_model.py
@@ -3304,10 +3304,10 @@ class TOMWrapper:
 
         def create_pattern(tableList, b):
             patterns = [
-                r"(?<!" + re.escape(table) + r"\[)(?<!" + re.escape(table) + r"'\[)"
+                r"(?<!" + re.escape(table) + r")(?<!" + re.escape(table) + r"')\["
                 for table in tableList
             ]
-            combined_pattern = "".join(patterns) + re.escape(b)
+            combined_pattern = "".join(patterns) + re.escape(b) + r"\]"
             return combined_pattern
 
         for obj in self.depends_on(object=object, dependencies=dependencies):


### PR DESCRIPTION
Ran across an issue of a measure that includes the same word as a column triggering a failure for the unqualified columns check. 

Example:
```dax
VAR Revenue =
    CALCULATE (
        SUMX (Opportunities, Opportunities[Value] ),
        FILTER (Opportunities, Opportunities[Status] = "Open" && VALUE(LEFT(Opportunities[Sales Stage Sort],1)) >=2))
RETURN
    Revenue + ( Revenue * ([Forecast Adjustment Value] / 100 ) )
```
Because `Value` is a column, the rule checks if it is prepended with `Opportunities[`. However, as it is also in the measure `Forecast Adjustment Value` it also triggers.

Believe updating the REGEX to force a match for the opening and closing square bracket should solve this.

