### PR TITLE
Add notebook to list large semantic models

### DIFF
--- a/notebooks/List Large Semantic Models.ipynb
+++ b/notebooks/List Large Semantic Models.ipynb
@@ -1,0 +1,116 @@
+{
+    "cells": [
+        {
+            "cell_type": "code",
+            "source": [
+                "%pip install semantic-link-labs"
+            ],
+            "outputs": [],
+            "execution_count": null,
+            "metadata": {
+                "microsoft": {
+                    "language": "python",
+                    "language_group": "synapse_pyspark"
+                }
+            },
+            "id": "22cf8d6a-169f-4264-9f66-6960a910b29b"
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "import pyspark.sql.functions\n",
+                "import sempy_labs\n",
+                "\n",
+                "datasets_df = spark.createDataFrame(sempy_labs.admin.list_datasets())\n",
+                "\n",
+                "workspaces_df = spark.createDataFrame(sempy_labs.admin.list_workspaces()) \\\n",
+                "    .select(pyspark.sql.functions.col(\"Id\").alias(\"Workspace Id\"), pyspark.sql.functions.col(\"Name\").alias(\"Workspace Name\"))\n",
+                "\n",
+                "datasets_df = datasets_df.join(workspaces_df, \"Workspace Id\", \"inner\")\n",
+                "datasets_df = datasets_df.where(pyspark.sql.functions.col(\"Target Storage Mode\") == pyspark.sql.functions.lit(\"PremiumFiles\"))"
+            ],
+            "outputs": [],
+            "execution_count": null,
+            "metadata": {
+                "jupyter": {
+                    "source_hidden": false,
+                    "outputs_hidden": false
+                },
+                "nteract": {
+                    "transient": {
+                        "deleting": false
+                    }
+                },
+                "microsoft": {
+                    "language": "python",
+                    "language_group": "synapse_pyspark"
+                },
+                "collapsed": false
+            },
+            "id": "0037de29-30a7-45f6-9960-bd7cd6aaafa6"
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "display(datasets_df)"
+            ],
+            "outputs": [],
+            "execution_count": null,
+            "metadata": {
+                "jupyter": {
+                    "source_hidden": false,
+                    "outputs_hidden": false
+                },
+                "nteract": {
+                    "transient": {
+                        "deleting": false
+                    }
+                },
+                "microsoft": {
+                    "language": "python",
+                    "language_group": "synapse_pyspark"
+                },
+                "collapsed": false
+            },
+            "id": "0f5ca5a8-bbde-4b0f-993f-8b0e9cf45771"
+        }
+    ],
+    "metadata": {
+        "kernel_info": {
+            "name": "synapse_pyspark"
+        },
+        "kernelspec": {
+            "name": "synapse_pyspark",
+            "language": "Python",
+            "display_name": "Synapse PySpark"
+        },
+        "language_info": {
+            "name": "python"
+        },
+        "microsoft": {
+            "language": "python",
+            "language_group": "synapse_pyspark",
+            "ms_spell_check": {
+                "ms_spell_check_language": "en"
+            }
+        },
+        "nteract": {
+            "version": "nteract-front-end@1.0.0"
+        },
+        "spark_compute": {
+            "compute_id": "/trident/default",
+            "session_options": {
+                "conf": {
+                    "spark.synapse.nbs.session.timeout": "1200000"
+                }
+            }
+        },
+        "synapse_widget": {
+            "version": "0.1",
+            "state": {}
+        },
+        "dependencies": {}
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
+}


### PR DESCRIPTION
When migrating capacities, extra action is needed when moving workspaces between capacities in different regions if large semantic models exist in the workspace. It would be useful to have a notebook to list those semantic models.