### PR TITLE
Handle optional columns in executeQueries API call

### DIFF
--- a/src/sempy_labs/_dax.py
+++ b/src/sempy_labs/_dax.py
@@ -62,9 +62,23 @@ def evaluate_dax_impersonation(
         payload=payload,
     )
     data = response.json()["results"][0]["tables"]
-    column_names = data[0]["rows"][0].keys()
-    data_rows = [row.values() for item in data for row in item["rows"]]
-    df = pd.DataFrame(data_rows, columns=column_names)
+    
+    # Get all possible column names from all rows because null columns aren't returned
+    all_columns = set()
+    for item in data:
+        for row in item["rows"]:
+            all_columns.update(row.keys())
+    
+    # Create rows with all columns, filling missing values with None
+    rows = []
+    for item in data:
+        for row in item["rows"]:
+            # Create a new row with all columns, defaulting to None
+            new_row = {col: row.get(col) for col in all_columns}
+            rows.append(new_row)
+    
+    # Create DataFrame from the processed rows
+    df = pd.DataFrame(rows)
 
     return df
 


### PR DESCRIPTION
if the first returned row of a query doesn't contain all possible columns, the current code creates an incorrect dataframe. 

description of row keys() length for one of my queries:
count: 13586.
mean: 10.09
std: 0.97
min: 7.0
25%: 9.0
50%: 10.0
75%: 11.0
max: 11.0

this fix builds a complete column list before building the resultant dataframe, backfilling with none 


