### PR TITLE
make destination lakehouse optional when creating onelake shortcuts

### DIFF
--- a/src/sempy_labs/_helper_functions.py
+++ b/src/sempy_labs/_helper_functions.py
@@ -347,6 +347,10 @@ def resolve_lakehouse_name_and_id(
 
     if lakehouse is None:
         lakehouse_id = fabric.get_lakehouse_id()
+        if lakehouse_id == '':
+            raise ValueError(
+                f"{icons.red_dot} Can't resolve lakehouse. Make sure a lakehouse is attached to the notebook or provide one via name or ID."
+            )
         lakehouse_name = fabric.resolve_item_name(
             item_id=lakehouse_id, type=type, workspace=workspace_id
         )

--- a/src/sempy_labs/lakehouse/_shortcuts.py
+++ b/src/sempy_labs/lakehouse/_shortcuts.py
@@ -18,7 +18,7 @@ def create_shortcut_onelake(
     table_name: str,
     source_lakehouse: str,
     source_workspace: str | UUID,
-    destination_lakehouse: str,
+    destination_lakehouse: Optional[str | UUID] = None,
     destination_workspace: Optional[str | UUID] = None,
     shortcut_name: Optional[str] = None,
     source_path: str = "Tables",
@@ -37,8 +37,10 @@ def create_shortcut_onelake(
         The Fabric lakehouse in which the table resides.
     source_workspace : str | uuid.UUID
         The name or ID of the Fabric workspace in which the source lakehouse exists.
-    destination_lakehouse : str
-        The Fabric lakehouse in which the shortcut will be created.
+    destination_lakehouse : str | uuid.UUID, default=None
+        The name or ID of the Fabric lakehouse in which the shortcut will be created.
+        Defaults to None which resolves to the attached lakehouse.
+        If no lakehouse is provided or attached the function will fail
     destination_workspace : str | uuid.UUID, default=None
         The name or ID of the Fabric workspace in which the shortcut will be created.
         Defaults to None which resolves to the workspace of the attached lakehouse


### PR DESCRIPTION
This PR makes destination lakehouse optional which will resolve to attached lakehouse on the notebook

as is today you can get the same by providing `destination_lakehouse=None` 
This PR makes it official and documented

Improve a bit the error handling if no lakehouse is attached or no ID or Name are provided 