### PR TITLE
Fix duplicated escaping of column names

### DIFF
--- a/src/sempy_labs/tom/_model.py
+++ b/src/sempy_labs/tom/_model.py
@@ -2257,7 +2257,7 @@ class TOMWrapper:
 
         if validate:
             dax_query = f"""
-            define measure '{table_name}'[test] = 
+            define measure '{table_name}'[test] =
             var mn = MIN('{table_name}'[{column_name}])
             var ma = MAX('{table_name}'[{column_name}])
             var x = COUNTROWS(DISTINCT('{table_name}'[{column_name}]))
@@ -3489,7 +3489,7 @@ class TOMWrapper:
                         tableList.append(c.Parent.Name)
                 if (
                     re.search(
-                        create_pattern(tableList, re.escape(obj.Name)),
+                        create_pattern(tableList, obj.Name),
                         expr,
                     )
                     is not None


### PR DESCRIPTION
Remove duplicate escaping of column names when calculating column qualfication violations for BPA.