### PR TITLE
Fix missing calc cols/tables in TOMWrapper.depends_on

### DIFF
--- a/src/sempy_labs/tom/_model.py
+++ b/src/sempy_labs/tom/_model.py
@@ -3309,14 +3309,16 @@ class TOMWrapper:
             .tolist()
         )
         cols = (
-            fil[fil["Referenced Object Type"] == "Column"][
+            fil[fil["Referenced Object Type"].isin(["Column", "Calc Column"])][
                 "Referenced Full Object Name"
             ]
             .unique()
             .tolist()
         )
         tbls = (
-            fil[fil["Referenced Object Type"] == "Table"]["Referenced Table"]
+            fil[fil["Referenced Object Type"].isin(["Table", "Calc Table"])][
+                "Referenced Table"
+            ]
             .unique()
             .tolist()
         )


### PR DESCRIPTION
Fix TOMWrapper.depends_on not returning calculated columns and calculated tables.