### PR TITLE
Minor Fix: _delta_analyzer_history.py

### DIFF
--- a/src/sempy_labs/_delta_analyzer_history.py
+++ b/src/sempy_labs/_delta_analyzer_history.py
@@ -55,7 +55,10 @@ def delta_analyzer_history(
 
     table_path = create_abfss_path(lakehouse_id, workspace_id, table_name, schema)
     local_path = _mount(lakehouse=lakehouse, workspace=workspace)
-    table_path_local = f"{local_path}/Tables/{table_name}"
+    if schema: #use schema if specified
+        table_path_local = f"{local_path}/Tables/{schema}/{table_name}"
+    else:
+        table_path_local = f"{local_path}/Tables/{table_name}"
     delta_table_path = f"{table_path}/_delta_log"
 
     files = notebookutils.fs.ls(delta_table_path)


### PR DESCRIPTION
`delta_analyzer_history` throws an error if a lakehouse withs schema is used (see below) because it does not the schema in the `table_path_local ` variable.
```
FileNotFoundError                         Traceback (most recent call last)
Cell In[16], line 4
      1 from sempy_labs import delta_analyzer_history
      3 # Analyze the Delta table history
----> 4 history_df = delta_analyzer_history(
      5     table_name="customers", schema="dbo"
      6 )
      8 # Display the results
      9 display(history_df)
      
      FileNotFoundError: [Errno 2] Failed to open local file '/lakehouse/default/Tables/customers/part-00000-c57f0015-d03a-4aed-955d-d1ad015858bd-c000.snappy.parquet'. Detail: [errno 2] No such file or directory
```

Updated the function to check for schema as below:

```
    if schema:
        table_path_local = f"{local_path}/Tables/{schema}/{table_name}"
    else:
        table_path_local = f"{local_path}/Tables/{table_name}"
```

With this change the function works as expected for both lakehouse and without schema. No other changes made. Please review,
