### PR TITLE
Handling empty SQL endpoint refresh

### DIFF
--- a/src/sempy_labs/_sql_endpoints.py
+++ b/src/sempy_labs/_sql_endpoints.py
@@ -157,45 +157,52 @@ def refresh_sql_endpoint_metadata(
         "Error Message": "string",
     }
 
-    df = pd.json_normalize(result)
+    if result:
+        df = pd.json_normalize(result)
 
-    # Extract error code and message, set to None if no error
-    df["Error Code"] = df.get("error.errorCode", None)
-    df["Error Message"] = df.get("error.message", None)
+        # Extract error code and message, set to None if no error
+        df["Error Code"] = df.get("error.errorCode", None)
+        df["Error Message"] = df.get("error.message", None)
 
-    # Friendly column renaming
-    df.rename(
-        columns={
-            "tableName": "Table Name",
-            "startDateTime": "Start Time",
-            "endDateTime": "End Time",
-            "status": "Status",
-            "lastSuccessfulSyncDateTime": "Last Successful Sync Time",
-        },
-        inplace=True,
-    )
+        # Friendly column renaming
+        df.rename(
+            columns={
+                "tableName": "Table Name",
+                "startDateTime": "Start Time",
+                "endDateTime": "End Time",
+                "status": "Status",
+                "lastSuccessfulSyncDateTime": "Last Successful Sync Time",
+            },
+            inplace=True,
+        )
 
-    # Drop the original 'error' column if present
-    df.drop(columns=[col for col in ["error"] if col in df.columns], inplace=True)
+        # Drop the original 'error' column if present
+        df.drop(columns=[col for col in ["error"] if col in df.columns], inplace=True)
 
-    # Optional: Reorder columns
-    column_order = [
-        "Table Name",
-        "Status",
-        "Start Time",
-        "End Time",
-        "Last Successful Sync Time",
-        "Error Code",
-        "Error Message",
-    ]
-    df = df[column_order]
+        # Optional: Reorder columns
+        column_order = [
+            "Table Name",
+            "Status",
+            "Start Time",
+            "End Time",
+            "Last Successful Sync Time",
+            "Error Code",
+            "Error Message",
+        ]
+        df = df[column_order]
+
+        printout = f"{icons.green_dot} The metadata of the SQL endpoint for the '{item_name}' {type.lower()} within the '{workspace_name}' workspace has been refreshed"
+        if tables:
+            print(f"{printout} for the following tables: {tables}.")
+        else:
+            print(f"{printout} for all tables.")
+    else:
+        # If the target item has no tables to refresh the metadata for
+        df = pd.DataFrame(columns=columns.keys())
+        print(
+            f"{icons.yellow_dot} The SQL endpoint '{item_name}' {type.lower()} within the '{workspace_name}' workspace has no tables to refresh..."
+        )
 
     _update_dataframe_datatypes(df, columns)
-
-    printout = f"{icons.green_dot} The metadata of the SQL endpoint for the '{item_name}' {type.lower()} within the '{workspace_name}' workspace has been refreshed"
-    if tables:
-        print(f"{printout} for the following tables: {tables}.")
-    else:
-        print(f"{printout} for all tables.")
 
     return df


### PR DESCRIPTION
Currently, refreshing a SQL endpoint using Semantic Link Labs using `refresh_sql_endpoint_metadata` function fails when the target Lakehouse has no tables and we don't specify tables parameter in the function, for example:
```python
refresh_sql_endpoint_metadata(item = 'landing', type = 'Lakehouse', workspace = 'Fabric Workspace', tables = None)
```

This execution will fail with the following error message:
![image](https://github.com/user-attachments/assets/702025d3-3c3e-4706-8095-4f2a7ea64758)
Error is caused by the fact that the API endpoint to refresh the SQL endpoint returns an empty response (but is a successful) when the Lakehouse is empty so the dataframe `df` will be empty and will cause the index issue when trying to reorder the columns (which do not exist).

The expected behavior of refreshing the empty SQL endpoint would be a successful execution of the function.

The proposed changes check if the response is empty or not:
- if not empty: continue with old code
- if empty: create an empty dataframe for return value and print a message

An example of the new output:
<img width="812" alt="semantic-link-labs-error-2" src="https://github.com/user-attachments/assets/33c36155-979e-41f7-a13f-cf49ba6d067c" />



Semantic link labs version: `0.10.1`