### PR TITLE
Bugfix: Include all capacities in list_capacities output

### DIFF
--- a/src/sempy_labs/admin/_capacities.py
+++ b/src/sempy_labs/admin/_capacities.py
@@ -285,16 +285,16 @@ def list_capacities(
                 "Users": i.get("users", []),
             }
 
-        if include_tenant_key:
-            tenant_key = i.get("tenantKey") or {}
-            row.update(
-                {
-                    "Tenant Key Id": tenant_key.get("id"),
-                    "Tenant Key Name": tenant_key.get("name"),
-                }
-            )
+            if include_tenant_key:
+                tenant_key = i.get("tenantKey") or {}
+                row.update(
+                    {
+                        "Tenant Key Id": tenant_key.get("id"),
+                        "Tenant Key Name": tenant_key.get("name"),
+                    }
+                )
 
-        rows.append(row)
+            rows.append(row)
 
     if rows:
         df = pd.DataFrame(rows, columns=list(columns.keys()))


### PR DESCRIPTION
**Summary**
Fixed an issue where the admin function list_capacities returned only one row even when multiple capacities were available.

**Details**

- Root Cause:rows.append(row) was placed outside the inner loop, so only the last capacity from each response page was added to the DataFrame.
- Fix: Moved rows.append(row) inside the inner loop to ensure all capacities are included in the result.