### PR TITLE
Graph API pagination

### DIFF
--- a/src/sempy_labs/graph/_groups.py
+++ b/src/sempy_labs/graph/_groups.py
@@ -55,7 +55,7 @@ def list_groups() -> pd.DataFrame:
         A pandas dataframe showing a list of groups and their properties.
     """
 
-    result = _base_api(request="groups", client="graph").json()
+    result = _base_api(request="groups", client="graph", uses_pagination=True)
 
     columns = {
         "Group Id": "string",
@@ -76,24 +76,25 @@ def list_groups() -> pd.DataFrame:
     df = _create_dataframe(columns=columns)
 
     rows = []
-    for v in result.get("value"):
-        rows.append(
-            {
-                "Group Id": v.get("id"),
-                "Group Name": v.get("displayName"),
-                "Mail": v.get("mail"),
-                "Description": v.get("description"),
-                "Classification": v.get("classification"),
-                "Mail Enabled": v.get("mailEnabled"),
-                "Security Enabled": v.get("securityEnabled"),
-                "Created Date Time": v.get("createdDateTime"),
-                "Expiration Date Time": v.get("expirationDateTime"),
-                "Renewed Date Time": v.get("renewedDateTime"),
-                "Deleted Date Time": v.get("deletedDateTime"),
-                "Visibility": v.get("visibility"),
-                "Security Identifier": v.get("securityIdentifier"),
-            }
-        )
+    for r in result:
+        for v in r.get("value", []):
+            rows.append(
+                {
+                    "Group Id": v.get("id"),
+                    "Group Name": v.get("displayName"),
+                    "Mail": v.get("mail"),
+                    "Description": v.get("description"),
+                    "Classification": v.get("classification"),
+                    "Mail Enabled": v.get("mailEnabled"),
+                    "Security Enabled": v.get("securityEnabled"),
+                    "Created Date Time": v.get("createdDateTime"),
+                    "Expiration Date Time": v.get("expirationDateTime"),
+                    "Renewed Date Time": v.get("renewedDateTime"),
+                    "Deleted Date Time": v.get("deletedDateTime"),
+                    "Visibility": v.get("visibility"),
+                    "Security Identifier": v.get("securityIdentifier"),
+                }
+            )
 
     if rows:
         df = pd.DataFrame(rows, columns=list(columns.keys()))
@@ -190,7 +191,7 @@ def list_group_members(group: str | UUID) -> pd.DataFrame:
 
     group_id = resolve_group_id(group)
 
-    result = _base_api(request=f"groups/{group_id}/members", client="graph").json()
+    result = _base_api(request=f"groups/{group_id}/members", client="graph", uses_pagination=True)
 
     columns = {
         "Member Id": "string",
@@ -209,22 +210,23 @@ def list_group_members(group: str | UUID) -> pd.DataFrame:
     df = _create_dataframe(columns=columns)
 
     rows = []
-    for v in result.get("value"):
-        rows.append(
-            {
-                "Member Id": v.get("id"),
-                "Member Name": v.get("displayName"),
-                "User Principal Name": v.get("userPrincipalName"),
-                "Mail": v.get("mail"),
-                "Job Title": v.get("jobTitle"),
-                "Office Location": v.get("officeLocation"),
-                "Mobile Phone": v.get("mobilePhone"),
-                "Business Phones": str(v.get("businessPhones")),
-                "Preferred Language": v.get("preferredLanguage"),
-                "Given Name": v.get("givenName"),
-                "Surname": v.get("surname"),
-            }
-        )
+    for r in result:
+        for v in r.get("value", []):
+            rows.append(
+                {
+                    "Member Id": v.get("id"),
+                    "Member Name": v.get("displayName"),
+                    "User Principal Name": v.get("userPrincipalName"),
+                    "Mail": v.get("mail"),
+                    "Job Title": v.get("jobTitle"),
+                    "Office Location": v.get("officeLocation"),
+                    "Mobile Phone": v.get("mobilePhone"),
+                    "Business Phones": str(v.get("businessPhones")),
+                    "Preferred Language": v.get("preferredLanguage"),
+                    "Given Name": v.get("givenName"),
+                    "Surname": v.get("surname"),
+                }
+            )
 
     if rows:
         df = pd.DataFrame(rows, columns=list(columns.keys()))
@@ -254,7 +256,7 @@ def list_group_owners(group: str | UUID) -> pd.DataFrame:
 
     group_id = resolve_group_id(group)
 
-    result = _base_api(request=f"groups/{group_id}/owners", client="graph").json()
+    result = _base_api(request=f"groups/{group_id}/owners", client="graph", uses_pagination=True)
 
     columns = {
         "Owner Id": "string",
@@ -273,22 +275,23 @@ def list_group_owners(group: str | UUID) -> pd.DataFrame:
     df = _create_dataframe(columns=columns)
 
     rows = []
-    for v in result.get("value"):
-        rows.append(
-            {
-                "Owner Id": v.get("id"),
-                "Owner Name": v.get("displayName"),
-                "User Principal Name": v.get("userPrincipalName"),
-                "Mail": v.get("mail"),
-                "Job Title": v.get("jobTitle"),
-                "Office Location": v.get("officeLocation"),
-                "Mobile Phone": v.get("mobilePhone"),
-                "Business Phones": str(v.get("businessPhones")),
-                "Preferred Language": v.get("preferredLanguage"),
-                "Given Name": v.get("givenName"),
-                "Surname": v.get("surname"),
-            }
-        )
+    for r in result:
+        for v in r.get("value", []):
+            rows.append(
+                {
+                    "Owner Id": v.get("id"),
+                    "Owner Name": v.get("displayName"),
+                    "User Principal Name": v.get("userPrincipalName"),
+                    "Mail": v.get("mail"),
+                    "Job Title": v.get("jobTitle"),
+                    "Office Location": v.get("officeLocation"),
+                    "Mobile Phone": v.get("mobilePhone"),
+                    "Business Phones": str(v.get("businessPhones")),
+                    "Preferred Language": v.get("preferredLanguage"),
+                    "Given Name": v.get("givenName"),
+                    "Surname": v.get("surname"),
+                }
+            )
 
     if rows:
         df = pd.DataFrame(rows, columns=list(columns.keys()))

--- a/src/sempy_labs/graph/_groups.py
+++ b/src/sempy_labs/graph/_groups.py
@@ -191,7 +191,9 @@ def list_group_members(group: str | UUID) -> pd.DataFrame:
 
     group_id = resolve_group_id(group)
 
-    result = _base_api(request=f"groups/{group_id}/members", client="graph", uses_pagination=True)
+    result = _base_api(
+        request=f"groups/{group_id}/members", client="graph", uses_pagination=True
+    )
 
     columns = {
         "Member Id": "string",
@@ -256,7 +258,9 @@ def list_group_owners(group: str | UUID) -> pd.DataFrame:
 
     group_id = resolve_group_id(group)
 
-    result = _base_api(request=f"groups/{group_id}/owners", client="graph", uses_pagination=True)
+    result = _base_api(
+        request=f"groups/{group_id}/owners", client="graph", uses_pagination=True
+    )
 
     columns = {
         "Owner Id": "string",

--- a/src/sempy_labs/graph/_teams.py
+++ b/src/sempy_labs/graph/_teams.py
@@ -23,7 +23,7 @@ def list_teams() -> pd.DataFrame:
         A pandas dataframe showing a list of teams and their properties.
     """
 
-    result = _base_api(request="teams", client="graph").json()
+    result = _base_api(request="teams", client="graph", uses_pagination=True)
 
     columns = {
         "Team Id": "str",
@@ -43,23 +43,24 @@ def list_teams() -> pd.DataFrame:
     df = _create_dataframe(columns=columns)
 
     rows = []
-    for v in result.get("value"):
-        rows.append(
-            {
-                "Team Id": v.get("id"),
-                "Team Name": v.get("displayName"),
-                "Description": v.get("description"),
-                "Creation Date Time": v.get("createdDateTime"),
-                "Classification": v.get("classification"),
-                "Specialization": v.get("specialization"),
-                "Visibility": v.get("visibility"),
-                "Web Url": v.get("webUrl"),
-                "Archived": v.get("isArchived"),
-                "Favorite By Me": v.get("isFavoriteByMe"),
-                "Discoverable By Me": v.get("isDiscoverableByMe"),
-                "Member Count": v.get("memberCount"),
-            }
-        )
+    for r in result:
+        for v in r.get("value", []):
+            rows.append(
+                {
+                    "Team Id": v.get("id"),
+                    "Team Name": v.get("displayName"),
+                    "Description": v.get("description"),
+                    "Creation Date Time": v.get("createdDateTime"),
+                    "Classification": v.get("classification"),
+                    "Specialization": v.get("specialization"),
+                    "Visibility": v.get("visibility"),
+                    "Web Url": v.get("webUrl"),
+                    "Archived": v.get("isArchived"),
+                    "Favorite By Me": v.get("isFavoriteByMe"),
+                    "Discoverable By Me": v.get("isDiscoverableByMe"),
+                    "Member Count": v.get("memberCount"),
+                }
+            )
 
     if rows:
         df = pd.DataFrame(rows, columns=list(columns.keys()))


### PR DESCRIPTION
Using a current version of `graph` module and particularly `graph.list_groups()` function is not feasible as the function does not support pagination and returns only top 100 groups.

This PR:
1. Adds a new `graph_pagination` function to the `_helper_functions.py` file which handles the graph api specific pagination (using odata.nextLink)
2. In the `_base_api` function, adds conditional statement to check if the client is `graph`, then perform graph api specific pagination, otherwise - standard Fabric one
3. Adjusts list functions in `graph` module to include pagination handling


P.S. *Could not test `list_sensitivity_labels` function so unsure if that one also requires the pagination handling.*
