### PR TITLE
Add notebook for migrating semantic models and reports between workspaces using Semantic Links

### DIFF
--- a/notebooks/Migrate Semantic Model&Report.ipynb
+++ b/notebooks/Migrate Semantic Model&Report.ipynb
@@ -1,0 +1,392 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# **Migrating Semantic Models and Reports between Workspaces**\n",
+    "\n",
+    "This notebook uses the native `semantic-link-labs` functions to:\n",
+    "- Migrate semantic models between workspaces\n",
+    "- Clone reports between workspaces\n",
+    "\n",
+    "**Documentation:**\n",
+    "- [deploy_semantic_model](https://semantic-link-labs.readthedocs.io/en/stable/sempy_labs.html#sempy_labs.deploy_semantic_model)\n",
+    "- [clone_report](https://semantic-link-labs.readthedocs.io/en/stable/sempy_labs.report.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Install Semantic Link Labs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install semantic-link-labs --upgrade"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sempy_labs as labs\n",
+    "from sempy_labs.report import clone_report\n",
+    "import sempy.fabric as fabric"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Workspace and Resource Configuration\n",
+    "\n",
+    "Define the IDs/names of your source and target workspaces:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Source workspace\n",
+    "SOURCE_WORKSPACE = \"XXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX\"  # Can be name or ID\n",
+    "\n",
+    "# Target workspace\n",
+    "TARGET_WORKSPACE = \"XXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX\"  # Can be name or ID\n",
+    "\n",
+    "# Semantic Model (Dataset)\n",
+    "SOURCE_DATASET_NAME = \"Gold_Semantic\"  # Name of the source dataset\n",
+    "TARGET_DATASET_NAME = \"Gold_Semantic_Migrated\"  # Name of the dataset in target\n",
+    "\n",
+    "# Report (optional)\n",
+    "SOURCE_REPORT_NAME = \"Report\"  # Name of the report to clone\n",
+    "TARGET_REPORT_NAME = \"Reporte_Cloned\"  # Name of the cloned report"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Migrate Semantic Model\n",
+    "\n",
+    "Use `deploy_semantic_model` to copy a semantic model from one workspace to another.\n",
+    "\n",
+    "**Main parameters:**\n",
+    "- `source_dataset`: Name of the source semantic model\n",
+    "- `source_workspace`: Source workspace (name or ID)\n",
+    "- `target_dataset`: Name of the new semantic model in target\n",
+    "- `target_workspace`: Target workspace (name or ID)\n",
+    "- `refresh_target_dataset`: If True, refreshes the dataset after creating it (default: True)\n",
+    "- `overwrite`: If True, overwrites the dataset if it already exists (default: False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Option 1: Migrate semantic model WITHOUT overwriting if it already exists\n",
+    "try:\n",
+    "    labs.deploy_semantic_model(\n",
+    "        source_dataset=SOURCE_DATASET_NAME,\n",
+    "        source_workspace=SOURCE_WORKSPACE,\n",
+    "        target_dataset=TARGET_DATASET_NAME,\n",
+    "        target_workspace=TARGET_WORKSPACE,\n",
+    "        refresh_target_dataset=True,  # Refresh after creating\n",
+    "        overwrite=False  # Don't overwrite if already exists\n",
+    "    )\n",
+    "    print(f\"✅ Semantic model '{TARGET_DATASET_NAME}' migrated successfully\")\n",
+    "except Exception as e:\n",
+    "    print(f\"❌ Error migrating semantic model: {str(e)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Option 2: Migrate semantic model OVERWRITING if it already exists\n",
+    "try:\n",
+    "    labs.deploy_semantic_model(\n",
+    "        source_dataset=SOURCE_DATASET_NAME,\n",
+    "        source_workspace=SOURCE_WORKSPACE,\n",
+    "        target_dataset=TARGET_DATASET_NAME,\n",
+    "        target_workspace=TARGET_WORKSPACE,\n",
+    "        refresh_target_dataset=True,\n",
+    "        overwrite=True  # OVERWRITE if already exists\n",
+    "    )\n",
+    "    print(f\"✅ Semantic model '{TARGET_DATASET_NAME}' migrated/updated successfully\")\n",
+    "except Exception as e:\n",
+    "    print(f\"❌ Error migrating semantic model: {str(e)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Verify Migrated Semantic Model\n",
+    "\n",
+    "List the datasets in the target workspace to confirm the migration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List datasets in the target workspace\n",
+    "datasets = fabric.list_datasets(workspace=TARGET_WORKSPACE)\n",
+    "print(f\"\\nDatasets in target workspace:\")\n",
+    "print(datasets[['Dataset Name', 'Dataset ID', 'Created Timestamp']])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Clone Report (Optional)\n",
+    "\n",
+    "Use `clone_report` to clone a report from one workspace to another.\n",
+    "\n",
+    "**Main parameters:**\n",
+    "- `report`: Name of the source report\n",
+    "- `cloned_report`: Name of the cloned report\n",
+    "- `workspace`: Workspace where the original report is located\n",
+    "- `target_workspace`: Target workspace for the cloned report\n",
+    "- `target_dataset`: Name of the semantic model that the cloned report will use\n",
+    "- `target_dataset_workspace`: Workspace where the target semantic model is located"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clone report to the target workspace connecting it to the migrated semantic model\n",
+    "try:\n",
+    "    clone_report(\n",
+    "        report=SOURCE_REPORT_NAME,\n",
+    "        cloned_report=TARGET_REPORT_NAME,\n",
+    "        workspace=SOURCE_WORKSPACE,  # Workspace where the original report is located\n",
+    "        target_workspace=TARGET_WORKSPACE,  # Target workspace for the report\n",
+    "        target_dataset=TARGET_DATASET_NAME,  # Connect to the migrated semantic model\n",
+    "        target_dataset_workspace=TARGET_WORKSPACE  # Workspace of the semantic model\n",
+    "    )\n",
+    "    print(f\"✅ Report '{TARGET_REPORT_NAME}' cloned successfully\")\n",
+    "except Exception as e:\n",
+    "    print(f\"❌ Error cloning report: {str(e)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Verify Cloned Report"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List reports in the target workspace\n",
+    "reports = fabric.list_reports(workspace=TARGET_WORKSPACE)\n",
+    "print(f\"\\nReports in target workspace:\")\n",
+    "print(reports[['Name', 'Id']])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Helper Function for Complete Migration\n",
+    "\n",
+    "A function that combines semantic model migration and report cloning:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def migrate_complete_solution(\n",
+    "    source_workspace: str,\n",
+    "    target_workspace: str,\n",
+    "    source_dataset: str,\n",
+    "    target_dataset: str,\n",
+    "    source_report: str = None,\n",
+    "    target_report: str = None,\n",
+    "    overwrite_dataset: bool = False,\n",
+    "    refresh_dataset: bool = True\n",
+    "):\n",
+    "    \"\"\"\n",
+    "    Migrates a semantic model and optionally a report from one workspace to another.\n",
+    "    \n",
+    "    Args:\n",
+    "        source_workspace: Source workspace (name or ID)\n",
+    "        target_workspace: Target workspace (name or ID)\n",
+    "        source_dataset: Name of the source semantic model\n",
+    "        target_dataset: Name of the target semantic model\n",
+    "        source_report: Name of the report to clone (optional)\n",
+    "        target_report: Name of the cloned report (optional)\n",
+    "        overwrite_dataset: If True, overwrites the dataset if it exists\n",
+    "        refresh_dataset: If True, refreshes the dataset after creating it\n",
+    "    \n",
+    "    Returns:\n",
+    "        dict: Operation result\n",
+    "    \"\"\"\n",
+    "    results = {\n",
+    "        'dataset_migrated': False,\n",
+    "        'report_cloned': False,\n",
+    "        'errors': []\n",
+    "    }\n",
+    "    \n",
+    "    # 1. Migrate semantic model\n",
+    "    print(f\"🔄 Migrating semantic model '{source_dataset}'...\")\n",
+    "    try:\n",
+    "        labs.deploy_semantic_model(\n",
+    "            source_dataset=source_dataset,\n",
+    "            source_workspace=source_workspace,\n",
+    "            target_dataset=target_dataset,\n",
+    "            target_workspace=target_workspace,\n",
+    "            refresh_target_dataset=refresh_dataset,\n",
+    "            overwrite=overwrite_dataset\n",
+    "        )\n",
+    "        results['dataset_migrated'] = True\n",
+    "        print(f\"✅ Semantic model migrated: '{target_dataset}'\")\n",
+    "    except Exception as e:\n",
+    "        error_msg = f\"Error migrating semantic model: {str(e)}\"\n",
+    "        results['errors'].append(error_msg)\n",
+    "        print(f\"❌ {error_msg}\")\n",
+    "        return results\n",
+    "    \n",
+    "    # 2. Clone report (if specified)\n",
+    "    if source_report and target_report:\n",
+    "        print(f\"\\n🔄 Cloning report '{source_report}'...\")\n",
+    "        try:\n",
+    "            clone_report(\n",
+    "                report=source_report,\n",
+    "                cloned_report=target_report,\n",
+    "                workspace=source_workspace,\n",
+    "                target_workspace=target_workspace,\n",
+    "                target_dataset=target_dataset,\n",
+    "                target_dataset_workspace=target_workspace\n",
+    "            )\n",
+    "            results['report_cloned'] = True\n",
+    "            print(f\"✅ Report cloned: '{target_report}'\")\n",
+    "        except Exception as e:\n",
+    "            error_msg = f\"Error cloning report: {str(e)}\"\n",
+    "            results['errors'].append(error_msg)\n",
+    "            print(f\"❌ {error_msg}\")\n",
+    "    \n",
+    "    return results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Use the Helper Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example: Execute the helper function to migrate both semantic model AND report\n",
+    "# This will run the complete migration process\n",
+    "result = migrate_complete_solution(\n",
+    "    source_workspace=SOURCE_WORKSPACE,\n",
+    "    target_workspace=TARGET_WORKSPACE,\n",
+    "    source_dataset=SOURCE_DATASET_NAME,\n",
+    "    target_dataset=TARGET_DATASET_NAME,\n",
+    "    source_report=SOURCE_REPORT_NAME,\n",
+    "    target_report=TARGET_REPORT_NAME,\n",
+    "    overwrite_dataset=False,\n",
+    "    refresh_dataset=True\n",
+    ")\n",
+    "\n",
+    "# Display the migration summary\n",
+    "print(\"\\n\" + \"=\"*50)\n",
+    "print(\"MIGRATION SUMMARY\")\n",
+    "print(\"=\"*50)\n",
+    "print(f\"Dataset migrated: {result['dataset_migrated']}\")\n",
+    "print(f\"Report cloned: {result['report_cloned']}\")\n",
+    "if result['errors']:\n",
+    "    print(f\"\\nErrors found:\")\n",
+    "    for error in result['errors']:\n",
+    "        print(f\"  - {error}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 10. List Reports Using a Semantic Model\n",
+    "\n",
+    "Useful to identify which reports depend on a semantic model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List reports that use the source semantic model\n",
+    "reports_using_dataset = labs.list_reports_using_semantic_model(\n",
+    "    dataset=SOURCE_DATASET_NAME,\n",
+    "    workspace=SOURCE_WORKSPACE\n",
+    ")\n",
+    "\n",
+    "print(f\"Reports that use the semantic model '{SOURCE_DATASET_NAME}':\")\n",
+    "print(reports_using_dataset)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR adds a new notebook demonstrating how to migrate semantic models and reports between Fabric workspaces.

**Key Features:**
- Step-by-step guide for semantic model migration using `deploy_semantic_model()`
- Report cloning with `clone_report()` 
- Reusable helper function for complete migrations
- Verification and error handling examples
- Code to discover report dependencies

**Use Cases:**
- Moving solutions between dev/test/prod workspaces
- Workspace consolidation projects
- Creating copies of semantic models and reports
