### PR TITLE
Fix passing region for asazure in service principal authentication

### DIFF
--- a/src/sempy_labs/_authentication.py
+++ b/src/sempy_labs/_authentication.py
@@ -130,7 +130,7 @@ class ServicePrincipalTokenProvider(TokenCredential):
         if audience not in self._shorthand_scopes:
             raise NotImplementedError
 
-        return self.get_token(audience).token
+        return self.get_token(audience, region=region).token
 
     def get_token(self, *scopes, **kwargs) -> AccessToken:
         """


### PR DESCRIPTION
Bypass region to get_token for service principal credential in semantic-link-labs