### PR TITLE
Change 'Report Flags' to 'int_fillna' in report columns

### DIFF
--- a/src/sempy_labs/admin/_reports.py
+++ b/src/sempy_labs/admin/_reports.py
@@ -54,7 +54,7 @@ def list_reports(
         "Users": "string",
         "Subscriptions": "string",
         "Workspace Id": "string",
-        "Report Flags": "int",
+        "Report Flags": "int_fillna",
     }
 
     df = _create_dataframe(columns=columns)


### PR DESCRIPTION
int was being cast to a column containing null values which led to below error:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[10], line 1
----> 1 labs.admin.list_reports()

File ~/jupyter-env/python3.11/lib/python3.11/site-packages/sempy/_utils/_log.py:370, in mds_log.<locals>.get_wrapper.<locals>.log_decorator_wrapper(*args, **kwargs)
    367 start_time = time.perf_counter()
    369 try:
--> 370     result = func(*args, **kwargs)
    372     # The invocation for get_message_dict moves after the function
    373     # so it can access the state after the method call
    374     message.update(extractor.get_completion_message_dict(result, arg_dict))

File ~/jupyter-env/python3.11/lib/python3.11/site-packages/sempy_labs/admin/_reports.py:97, in list_reports(top, skip, filter)
     95 if rows:
     96     df = pd.DataFrame(rows, columns=list(columns.keys()))
---> 97     _update_dataframe_datatypes(dataframe=df, column_map=columns)
     99 return df

File ~/jupyter-env/python3.11/lib/python3.11/site-packages/sempy_labs/_helper_functions.py:2328, in _update_dataframe_datatypes(dataframe, column_map)
   2326 if column in dataframe.columns:
   2327     if data_type == "int":
-> 2328         dataframe[column] = dataframe[column].astype(int)
   2329     elif data_type == "bool":
   2330         dataframe[column] = dataframe[column].astype(bool)

File ~/jupyter-env/python3.11/lib/python3.11/site-packages/pandas/core/generic.py:6534, in NDFrame.astype(self, dtype, copy, errors)
   6530     results = [ser.astype(dtype, copy=copy) for _, ser in self.items()]
   6532 else:
   6533     # else, only a single dtype is given
-> 6534     new_data = self._mgr.astype(dtype=dtype, copy=copy, errors=errors)
   6535     res = self._constructor_from_mgr(new_data, axes=new_data.axes)
   6536     return res.__finalize__(self, method="astype")

File ~/jupyter-env/python3.11/lib/python3.11/site-packages/pandas/core/internals/managers.py:414, in BaseBlockManager.astype(self, dtype, copy, errors)
    411 elif using_copy_on_write():
    412     copy = False
--> 414 return self.apply(
    415     "astype",
    416     dtype=dtype,
    417     copy=copy,
    418     errors=errors,
    419     using_cow=using_copy_on_write(),
    420 )

File ~/jupyter-env/python3.11/lib/python3.11/site-packages/pandas/core/internals/managers.py:354, in BaseBlockManager.apply(self, f, align_keys, **kwargs)
    352         applied = b.apply(f, **kwargs)
    353     else:
--> 354         applied = getattr(b, f)(**kwargs)
    355     result_blocks = extend_blocks(applied, result_blocks)
    357 out = type(self).from_blocks(result_blocks, self.axes)

File ~/jupyter-env/python3.11/lib/python3.11/site-packages/pandas/core/internals/blocks.py:616, in Block.astype(self, dtype, copy, errors, using_cow)
    596 """
    597 Coerce to the new dtype.
    598 
   (...)
    612 Block
    613 """
    614 values = self.values
--> 616 new_values = astype_array_safe(values, dtype, copy=copy, errors=errors)
    618 new_values = maybe_coerce_values(new_values)
    620 refs = None

File ~/jupyter-env/python3.11/lib/python3.11/site-packages/pandas/core/dtypes/astype.py:238, in astype_array_safe(values, dtype, copy, errors)
    235     dtype = dtype.numpy_dtype
    237 try:
--> 238     new_values = astype_array(values, dtype, copy=copy)
    239 except (ValueError, TypeError):
    240     # e.g. _astype_nansafe can fail on object-dtype of strings
    241     #  trying to convert to float
    242     if errors == "ignore":

File ~/jupyter-env/python3.11/lib/python3.11/site-packages/pandas/core/dtypes/astype.py:183, in astype_array(values, dtype, copy)
    180     values = values.astype(dtype, copy=copy)
    182 else:
--> 183     values = _astype_nansafe(values, dtype, copy=copy)
    185 # in pandas we don't store numpy str dtypes, so convert to object
    186 if isinstance(dtype, np.dtype) and issubclass(values.dtype.type, str):

File ~/jupyter-env/python3.11/lib/python3.11/site-packages/pandas/core/dtypes/astype.py:134, in _astype_nansafe(arr, dtype, copy, skipna)
    130     raise ValueError(msg)
    132 if copy or arr.dtype == object or dtype == object:
    133     # Explicit copy, or required since NumPy can't view from / to object.
--> 134     return arr.astype(dtype, copy=True)
    136 return arr.astype(dtype, copy=copy)

TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```
changed type to 'int_fillna' which resolved the error and returned the dataframe successfully