### PR TITLE
Add support for MirroredAzureDatabricksCatalog in create_shortcut_onelake()

### DIFF
--- a/src/sempy_labs/lakehouse/_shortcuts.py
+++ b/src/sempy_labs/lakehouse/_shortcuts.py
@@ -55,7 +55,7 @@ def create_shortcut_onelake(
     source_item : str | uuid.UUID, default=None
         The source Fabric data store item in which the table resides. Can be either the Name or ID of the item.
     source_item_type: str, default="Lakehouse"
-        The source Fabric data store item type. Options are 'Lakehouse', 'Warehouse', 'MirroredDatabase', 'SQLDatabase', and 'KQLDatabase'.
+        The source Fabric data store item type. Options are 'Lakehouse', 'Warehouse', 'MirroredDatabase', 'SQLDatabase', 'KQLDatabase', and 'MirroredAzureDatabricksCatalog'.
     source_path : str, default="Tables"
         A string representing the full path to the table/file in the source lakehouse, including either "Files" or "Tables". Examples: Tables/FolderName/SubFolderName; Files/FolderName/SubFolderName.
     destination_path: str, default="Tables"
@@ -84,10 +84,17 @@ def create_shortcut_onelake(
         )
     if not (
         source_item_type
-        in ["Lakehouse", "Warehouse", "MirroredDatabase", "SQLDatabase", "KQLDatabase"]
+        in [
+            "Lakehouse",
+            "Warehouse",
+            "MirroredDatabase",
+            "SQLDatabase",
+            "KQLDatabase",
+            "MirroredAzureDatabricksCatalog",
+        ]
     ):
         raise ValueError(
-            f"{icons.red_dot} The 'source_item_type' parameter must be 'Lakehouse', 'Warehouse', 'MirroredDatabase', 'SQLDatabase', or 'KQLDatabase'"
+            f"{icons.red_dot} The 'source_item_type' parameter must be 'Lakehouse', 'Warehouse', 'MirroredDatabase', 'SQLDatabase', 'KQLDatabase', or 'MirroredAzureDatabricksCatalog'"
         )
 
     (source_workspace_name, source_workspace_id) = resolve_workspace_name_and_id(


### PR DESCRIPTION
### PR Summary & Background
Dan mentions in this [comment](https://github.com/microsoft/semantic-link-labs/pull/987#issuecomment-3715286981) that the newly merged PR for `_shortcuts.py` did not include support for the Mirrored Azure Databricks Catalog item type.

This PR adds support for creating shortcuts to Mirrored Azure Databricks Catalogs.

The core logic handles this scenario since the JSON payload passes in an `item_id`, and we get the item id from `resolve_item_name_and_id` which should handle this `source_item_type`. In this PR we are just updating the `source_item_type` to be able to handle "MirroredAzureDatabricksCatalog" as a value without returning an error.

> [!NOTE]
> I do not have access to a Mirrored Azure Databricks Catalog in my environment so I was not able to test the code changes. Someone else may need to test, but I believe it should work as-is.