### PR TITLE
Fix Add Members to Group

### DIFF
--- a/src/sempy_labs/graph/_groups.py
+++ b/src/sempy_labs/graph/_groups.py
@@ -381,7 +381,6 @@ def _base_add_to_group(
         object = [object]
 
     group_id = resolve_group_id(group)
-    url = f"groups/{group_id}/{object_type}/$ref"
 
     for m in object:
         if _is_valid_uuid(m):
@@ -397,17 +396,19 @@ def _base_add_to_group(
 
     # Must submit one request for each owner. Members can be sent in a single request.
     if object_type == "members":
+        url = f"groups/{group_id}"
         payload = {"members@odata.bind": object_list}
 
         _base_api(
             request=url,
             client="graph",
             payload=payload,
-            method="post",
+            method="patch",
             status_codes=204,
         )
 
     else:
+        url = f"groups/{group_id}/{object_type}/$ref"
         for o in object_list:
             payload = {"odata.id": o}
             _base_api(


### PR DESCRIPTION
Following the documentation on [how to add multiple members to a group in a single request](https://learn.microsoft.com/en-us/graph/api/group-post-members?view=graph-rest-1.0&tabs=http#example-2-add-multiple-members-to-a-group-in-a-single-request) fix the bug #1082

The code was mixing the different approaches in order to add a member to a group:

* Single Member to Group: `POST` to `groups/{group-id}/members/$ref` and `"@odata.id"` in body
* Multiple Members to Group: `PATCH` to `groups/{group-id}` and `"members@odata.bind"` in body

This PR fixes the multiple members approach for members object_type while maintaining the single member approach for all other object_types.