### PR TITLE
Add report quality fixers: ShowItemsNoData, unused visuals, measures, alignment

### DIFF
--- a/src/sempy_labs/report/_Fix_DisableShowItemsNoData.py
+++ b/src/sempy_labs/report/_Fix_DisableShowItemsNoData.py
@@ -1,0 +1,84 @@
+# Disable 'Show Items With No Data' in Power BI Reports
+# Removes the showAll property from all visuals, which disables the
+# "Show items with no data" setting that can cause performance issues.
+
+from uuid import UUID
+from typing import Optional
+from sempy._utils._log import log
+import sempy_labs._icons as icons
+from sempy_labs.report._reportwrapper import connect_report
+
+
+@log
+def fix_disable_show_items_no_data(
+    report: str | UUID,
+    page_name: Optional[str] = None,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+) -> None:
+    """
+    Disables the 'Show items with no data' property on all visuals in the
+    report. This setting can lead to performance degradation, especially
+    against large semantic models.
+
+    Parameters
+    ----------
+    report : str | uuid.UUID
+        Name or ID of the report.
+    page_name : str, default=None
+        The display name of the page to apply changes to.
+        Defaults to None which applies changes to all pages.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+        Defaults to None which resolves to the workspace of the attached lakehouse
+        or if no lakehouse attached, resolves to the workspace of the notebook.
+    scan_only : bool, default=False
+        If True, only scans and reports which visuals have showAll enabled
+        without making any changes.
+
+    Returns
+    -------
+    None
+    """
+
+    with connect_report(
+        report=report, workspace=workspace, readonly=scan_only, show_diffs=False
+    ) as rw:
+        if rw.format != "PBIR":
+            print(
+                f"{icons.red_dot} Report '{rw._report_name}' is in '{rw.format}' format, not PBIR. "
+                f"Run 'Upgrade to PBIR' first."
+            )
+            return
+
+        # List visuals and check which have "Show Items With No Data" enabled
+        dfV = rw.list_visuals()
+        if "Show Items With No Data" not in dfV.columns:
+            print("No visuals with 'Show items with no data' found. 0 changes needed.")
+            return
+
+        affected = dfV[dfV["Show Items With No Data"] == True]
+
+        if page_name:
+            affected = affected[
+                (affected["Page Display Name"] == page_name)
+                | (affected["Page Name"] == page_name)
+            ]
+
+        if affected.empty:
+            print("No visuals with 'Show items with no data' found. 0 changes needed.")
+            return
+
+        for _, row in affected.iterrows():
+            page_disp = row.get("Page Display Name", "")
+            visual_name = row.get("Visual Name", "")
+            if scan_only:
+                print(f"[SCAN] [{page_disp}] Visual '{visual_name}' has 'Show items with no data' enabled")
+            else:
+                print(f"[{page_disp}] Disabling 'Show items with no data' on '{visual_name}'")
+
+        if not scan_only:
+            rw.disable_show_items_with_no_data()
+            print(f"{icons.green_dot} Disabled 'Show items with no data' on {len(affected)} visual(s).")
+        else:
+            print(f"{len(affected)} visual(s) with 'Show items with no data' enabled.")

--- a/src/sempy_labs/report/_Fix_MigrateReportLevelMeasures.py
+++ b/src/sempy_labs/report/_Fix_MigrateReportLevelMeasures.py
@@ -1,0 +1,74 @@
+# Migrate Report-Level Measures to Semantic Model
+# Moves report-level measures from the report into the underlying semantic model.
+
+from uuid import UUID
+from typing import Optional
+from sempy._utils._log import log
+import sempy_labs._icons as icons
+from sempy_labs.report._reportwrapper import connect_report
+
+
+@log
+def fix_migrate_report_level_measures(
+    report: str | UUID,
+    page_name: Optional[str] = None,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+) -> None:
+    """
+    Migrates report-level measures from the report into the semantic model.
+    It is a best practice to keep measures defined in the semantic model,
+    not in the report.
+
+    Parameters
+    ----------
+    report : str | uuid.UUID
+        Name or ID of the report.
+    page_name : str, default=None
+        Ignored (report-level measures are report-wide). Kept for API consistency.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+        Defaults to None which resolves to the workspace of the attached lakehouse
+        or if no lakehouse attached, resolves to the workspace of the notebook.
+    scan_only : bool, default=False
+        If True, only scans and reports which report-level measures exist
+        without migrating them.
+
+    Returns
+    -------
+    None
+    """
+
+    with connect_report(
+        report=report, workspace=workspace, readonly=scan_only, show_diffs=False
+    ) as rw:
+        if rw.format != "PBIR":
+            print(
+                f"{icons.red_dot} Report '{rw._report_name}' is in '{rw.format}' format, not PBIR. "
+                f"Run 'Upgrade to PBIR' first."
+            )
+            return
+
+        dfRLM = rw.list_report_level_measures()
+
+        if dfRLM.empty:
+            print("No report-level measures found. 0 changes needed.")
+            return
+
+        for _, row in dfRLM.iterrows():
+            measure_name = row.get("Measure Name", "")
+            table_name = row.get("Table Name", "")
+            if scan_only:
+                print(f"[SCAN] Report-level measure: [{table_name}].[{measure_name}]")
+            else:
+                print(f"Migrating report-level measure: [{table_name}].[{measure_name}]")
+
+    if not scan_only:
+        # Re-open in write mode to actually migrate
+        with connect_report(
+            report=report, workspace=workspace, readonly=False, show_diffs=False
+        ) as rw:
+            rw.migrate_report_level_measures()
+            print(f"{icons.green_dot} Migrated {len(dfRLM)} report-level measure(s) to the semantic model.")
+    else:
+        print(f"{len(dfRLM)} report-level measure(s) found.")

--- a/src/sempy_labs/report/_Fix_RemoveUnusedCustomVisuals.py
+++ b/src/sempy_labs/report/_Fix_RemoveUnusedCustomVisuals.py
@@ -1,0 +1,68 @@
+# Remove Unused Custom Visuals from Power BI Reports
+# Removes any custom visuals registered in the report that are not used by any visual.
+
+from uuid import UUID
+from typing import Optional
+from sempy._utils._log import log
+import sempy_labs._icons as icons
+from sempy_labs.report._reportwrapper import connect_report
+
+
+@log
+def fix_remove_unused_custom_visuals(
+    report: str | UUID,
+    page_name: Optional[str] = None,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+) -> None:
+    """
+    Removes custom visuals that are registered in the report but not used
+    by any visual on any page.
+
+    Parameters
+    ----------
+    report : str | uuid.UUID
+        Name or ID of the report.
+    page_name : str, default=None
+        Ignored (custom visuals are report-level). Kept for API consistency.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+        Defaults to None which resolves to the workspace of the attached lakehouse
+        or if no lakehouse attached, resolves to the workspace of the notebook.
+    scan_only : bool, default=False
+        If True, only scans and reports unused custom visuals without removing them.
+
+    Returns
+    -------
+    None
+    """
+
+    with connect_report(
+        report=report, workspace=workspace, readonly=scan_only, show_diffs=False
+    ) as rw:
+        if rw.format != "PBIR":
+            print(
+                f"{icons.red_dot} Report '{rw._report_name}' is in '{rw.format}' format, not PBIR. "
+                f"Run 'Upgrade to PBIR' first."
+            )
+            return
+
+        dfCV = rw.list_custom_visuals()
+        unused = dfCV[dfCV["Used in Report"] == False]
+
+        if unused.empty:
+            print(f"No unused custom visuals found. 0 changes needed.")
+            return
+
+        for _, row in unused.iterrows():
+            display_name = row.get("Custom Visual Display Name", row.get("Custom Visual Name", ""))
+            if scan_only:
+                print(f"[SCAN] Unused custom visual: {display_name}")
+            else:
+                print(f"Removing unused custom visual: {display_name}")
+
+        if not scan_only:
+            rw.remove_unnecessary_custom_visuals()
+            print(f"{icons.green_dot} Removed {len(unused)} unused custom visual(s).")
+        else:
+            print(f"{len(unused)} unused custom visual(s) found.")

--- a/src/sempy_labs/report/_Fix_VisualAlignment.py
+++ b/src/sempy_labs/report/_Fix_VisualAlignment.py
@@ -1,0 +1,183 @@
+# Fix Visual Alignment — standalone report fixer.
+# Aligns chart visuals on a page by snapping nearly-aligned visuals to a common position/size.
+
+from typing import Optional
+from uuid import UUID
+
+
+# Chart visual types to check for alignment (actual data chart visuals only)
+_CHART_TYPES = {
+    "barChart", "clusteredBarChart", "stackedBarChart", "hundredPercentStackedBarChart",
+    "columnChart", "clusteredColumnChart", "stackedColumnChart", "hundredPercentStackedColumnChart",
+    "lineChart", "areaChart", "stackedAreaChart", "lineStackedColumnComboChart",
+    "lineClusteredColumnComboChart", "ribbonChart", "waterfallChart", "funnel",
+    "scatterChart", "pieChart", "donutChart",
+}
+
+
+def fix_visual_alignment(
+    report: str,
+    page_name: Optional[str] = None,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+    tolerance_pct: float = 2.0,
+):
+    """
+    Aligns chart visuals on report pages by snapping nearly-aligned visuals.
+
+    Visuals within `tolerance_pct` of the page dimension are snapped to a common
+    position (x or y) and resized to a common width/height.
+
+    Parameters
+    ----------
+    report : str
+        Name of the Power BI report.
+    page_name : str, default=None
+        Specific page to fix. If None, processes all pages.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    tolerance_pct : float, default=2.0
+        Percentage tolerance for alignment detection. Visuals within this % of
+        the page width/height are considered "nearly aligned" and will be snapped.
+    """
+    from sempy_labs.report import connect_report
+    import pandas as pd
+
+    total_fixes = 0
+
+    with connect_report(report=report, readonly=scan_only, workspace=workspace) as rw:
+        pages_df = rw.list_pages()
+        visuals_df = rw.list_visuals()
+
+        target_pages = pages_df if page_name is None else pages_df[
+            (pages_df["Page Display Name"] == page_name) | (pages_df["Page Name"] == page_name)
+        ]
+
+        for _, page_row in target_pages.iterrows():
+            p_name = str(page_row.get("Page Name", ""))
+            p_display = str(page_row.get("Page Display Name", ""))
+            p_width = float(page_row.get("Width", 1280))
+            p_height = float(page_row.get("Height", 720))
+
+            tol_x = p_width * tolerance_pct / 100.0
+            tol_y = p_height * tolerance_pct / 100.0
+
+            # Get chart visuals on this page
+            page_visuals = visuals_df[
+                (visuals_df["Page Name"] == p_name) &
+                (visuals_df["Type"].isin(_CHART_TYPES)) &
+                (visuals_df["Hidden"] == False)
+            ].copy()
+
+            if len(page_visuals) < 2:
+                continue
+
+            # --- Step 1: Resize nearly-same-sized visuals ---
+            # Group by approximate width (within tolerance)
+            widths = page_visuals["Width"].values
+            heights = page_visuals["Height"].values
+
+            # Find groups of similar widths
+            width_groups = _group_by_tolerance(page_visuals.index.tolist(), widths, tol_x)
+            for group_indices in width_groups:
+                if len(group_indices) < 2:
+                    continue
+                target_w = widths[group_indices[0]]
+                for gi in group_indices[1:]:
+                    if abs(widths[gi] - target_w) > 0 and abs(widths[gi] - target_w) <= tol_x:
+                        row = page_visuals.iloc[gi]
+                        if scan_only:
+                            print(f"  [{p_display}] Would resize width: '{row.get('Title', row['Visual Name'])}' {widths[gi]:.0f} -> {target_w:.0f}")
+                        else:
+                            _update_visual_pos(rw, row["File Path"], width=target_w)
+                        total_fixes += 1
+
+            # Find groups of similar heights
+            height_groups = _group_by_tolerance(page_visuals.index.tolist(), heights, tol_y)
+            for group_indices in height_groups:
+                if len(group_indices) < 2:
+                    continue
+                target_h = heights[group_indices[0]]
+                for gi in group_indices[1:]:
+                    if abs(heights[gi] - target_h) > 0 and abs(heights[gi] - target_h) <= tol_y:
+                        row = page_visuals.iloc[gi]
+                        if scan_only:
+                            print(f"  [{p_display}] Would resize height: '{row.get('Title', row['Visual Name'])}' {heights[gi]:.0f} -> {target_h:.0f}")
+                        else:
+                            _update_visual_pos(rw, row["File Path"], height=target_h)
+                        total_fixes += 1
+
+            # --- Step 2: Align x-positions (vertical columns) ---
+            x_vals = page_visuals["X"].values
+            x_groups = _group_by_tolerance(page_visuals.index.tolist(), x_vals, tol_x)
+            for group_indices in x_groups:
+                if len(group_indices) < 2:
+                    continue
+                target_x = x_vals[group_indices[0]]
+                for gi in group_indices[1:]:
+                    if abs(x_vals[gi] - target_x) > 0 and abs(x_vals[gi] - target_x) <= tol_x:
+                        row = page_visuals.iloc[gi]
+                        if scan_only:
+                            print(f"  [{p_display}] Would align X: '{row.get('Title', row['Visual Name'])}' {x_vals[gi]:.0f} -> {target_x:.0f}")
+                        else:
+                            _update_visual_pos(rw, row["File Path"], x=target_x)
+                        total_fixes += 1
+
+            # --- Step 3: Align y-positions (horizontal rows) ---
+            y_vals = page_visuals["Y"].values
+            y_groups = _group_by_tolerance(page_visuals.index.tolist(), y_vals, tol_y)
+            for group_indices in y_groups:
+                if len(group_indices) < 2:
+                    continue
+                target_y = y_vals[group_indices[0]]
+                for gi in group_indices[1:]:
+                    if abs(y_vals[gi] - target_y) > 0 and abs(y_vals[gi] - target_y) <= tol_y:
+                        row = page_visuals.iloc[gi]
+                        if scan_only:
+                            print(f"  [{p_display}] Would align Y: '{row.get('Title', row['Visual Name'])}' {y_vals[gi]:.0f} -> {target_y:.0f}")
+                        else:
+                            _update_visual_pos(rw, row["File Path"], y=target_y)
+                        total_fixes += 1
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {total_fixes} alignment issue(s).")
+    return total_fixes
+
+
+def _group_by_tolerance(indices, values, tolerance):
+    """Group indices by value proximity within tolerance."""
+    if len(values) == 0:
+        return []
+    sorted_pairs = sorted(zip(range(len(values)), values), key=lambda x: x[1])
+    groups = []
+    current_group = [sorted_pairs[0][0]]
+    current_anchor = sorted_pairs[0][1]
+
+    for i in range(1, len(sorted_pairs)):
+        idx, val = sorted_pairs[i]
+        if abs(val - current_anchor) <= tolerance:
+            current_group.append(idx)
+        else:
+            groups.append(current_group)
+            current_group = [idx]
+            current_anchor = val
+    groups.append(current_group)
+    return groups
+
+
+def _update_visual_pos(rw, file_path, x=None, y=None, width=None, height=None):
+    """Update a visual's position/size in the report definition."""
+    payload = rw.get(file_path=file_path)
+    pos = payload.get("position", {})
+    if x is not None:
+        pos["x"] = x
+    if y is not None:
+        pos["y"] = y
+    if width is not None:
+        pos["width"] = width
+    if height is not None:
+        pos["height"] = height
+    payload["position"] = pos
+    rw.update(file_path=file_path, payload=payload)


### PR DESCRIPTION
## Fix Report Quality

A bundle of four report-quality functions that address common Power BI report issues: disabling 'Show items with no data', removing unused custom visuals, migrating report-level measures to the semantic model, and aligning visuals on pages.

### Functions Added

| Function | Description |
|----------|-------------|
| `fix_disable_show_items_no_data(report, page_name=None, workspace=None, scan_only=False)` | Disables the 'Show items with no data' property on all visuals in the report. |
| `fix_remove_unused_custom_visuals(report, page_name=None, workspace=None, scan_only=False)` | Removes custom visuals that are registered in the report but not used by any visual on any page. |
| `fix_migrate_report_level_measures(report, page_name=None, workspace=None, scan_only=False)` | Migrates report-level measures from the report into the semantic model. |
| `fix_visual_alignment(report, page_name=None, workspace=None, scan_only=False, tolerance_pct=2.0)` | Aligns chart visuals on report pages by snapping nearly-aligned visuals (within `tolerance_pct` threshold). |

### Files

- `src/sempy_labs/report/_Fix_DisableShowItemsNoData.py` (new file)
- `src/sempy_labs/report/_Fix_RemoveUnusedCustomVisuals.py` (new file)
- `src/sempy_labs/report/_Fix_MigrateReportLevelMeasures.py` (new file)
- `src/sempy_labs/report/_Fix_VisualAlignment.py` (new file)
- `src/sempy_labs/report/__init__.py` (updated exports)

### Usage

```python
import sempy_labs as labs

# Remove unused custom visuals from a report
labs.report.fix_remove_unused_custom_visuals("My Report")

# Align visuals with 3% tolerance
labs.report.fix_visual_alignment("My Report", tolerance_pct=3.0)

# Migrate report-level measures into the semantic model
labs.report.fix_migrate_report_level_measures("My Report")

# Disable 'Show items with no data'
labs.report.fix_disable_show_items_no_data("My Report")
```

### Requirements

- Report must be in **PBIR format**.

---

## PBI Fixer Contribution — Overview

This PR is part of the **PBI Fixer** contribution to semantic-link-labs — an interactive ipywidgets-based UI for scanning and fixing Power BI reports and semantic models directly in Microsoft Fabric Notebooks.

The PBI Fixer provides a tabbed ipywidgets interface (Semantic Model Explorer, Report Explorer, Perspective Editor, Vertipaq Analyzer) that lets users interactively scan, inspect, and fix Power BI artifacts without leaving the notebook. All underlying fixer functions also work as standalone API calls, so users can integrate them into scripts and pipelines without the UI.

### Contribution Structure

The full contribution (~17K lines across 68 files) is split into **22 focused PRs across 6 phases** to keep each PR reviewable and self-contained. Only new files are added in Phases 1–4 and 6 — no existing SLL code is modified.

| Phase | Focus | PRs | Description |
|-------|-------|-----|-------------|
| **1** | **Report Fixers** | 7 | Standalone functions that programmatically fix common Power BI report issues: replace pie charts with bar charts, standardize page sizes to Full HD, apply chart formatting best practices, migrate slicers to slicerbars, hide visual-level filters, clean up unused custom visuals, align visuals, migrate report-level measures, and upgrade reports to PBIR format. Each function operates on PBIR-format report definitions. |
| **2** | **Semantic Model Fixers** | 4 | Functions that fix and enhance semantic models via XMLA/TOM: add calculated calendar and measure tables, add calculation groups for units and time intelligence, discourage implicit measures, and 19 BPA auto-fixers covering formatting conventions, naming standards, data types, column visibility, sort order, and DAX patterns (e.g., use DIVIDE instead of `/`). |
| **3** | **SM Setup & Analysis** | 3 | Setup utilities: configure cache warming queries, set up incremental refresh policies, and prepare semantic models for AI/Copilot integration (descriptions, metadata enrichment). |
| **4** | **Report Utilities** | 3 | Report-level utilities: auto-generate report page prototypes from a semantic model's structure, extract and apply report themes, and generate IBCS-compliant variance charts. |
| **5** | **Upstream Enhancements** | 3 | **⚠️ These PRs modify existing SLL code** (unlike Phases 1–4 which only add new files). Changes include TOM model `.Find()` fixes and expression capture (`tom/_model.py`), Vertipaq analyzer enhancements with memory/column-level analysis (`_vertipaq.py`, ~1000 lines changed), and various small fixes across `_items.py`, `_item_recovery.py`, `_helper_functions.py`, `_export_report.py`, `_sql.py`, and `admin/_tenant.py`. These carry higher merge conflict risk and may need closer review or discussion. |
| **6** | **PBI Fixer UI** | 2 | The interactive UI layer: shared UI components (theme, icons, tree builders, layout helpers), BPA scan runners, report helpers, and the main PBI Fixer application with its tabbed interface (SM Explorer, Report Explorer, Perspective Editor, Vertipaq Analyzer). Depends on Phases 1–5 but uses lazy imports to degrade gracefully if individual fixers aren't yet merged. |

### Dependencies & Review Order

- **Phases 1–4** are fully independent — they only add new files and can be reviewed/merged in any order.
- **Phase 5** is also independent but modifies existing code, so it may benefit from early discussion.
- **Phase 6** (the UI) ties everything together. It depends on the earlier phases but works standalone via lazy imports.
- All fixer functions work without the UI — they can be called directly as `sempy_labs.report.fix_piecharts(...)` or `sempy_labs.semantic_model.add_calculated_calendar(...)`.
