### PR TITLE
Add SM component creators: calendar, measure table, last refresh, calc groups

### DIFF
--- a/src/sempy_labs/semantic_model/_Add_CalcGroup_TimeIntelligence.py
+++ b/src/sempy_labs/semantic_model/_Add_CalcGroup_TimeIntelligence.py
@@ -1,0 +1,373 @@
+# Add "Time Intelligence" Calculation Group to Semantic Model
+# Based on: https://github.com/KornAlexander/PBI-Tools/.../2. Time Intelligence.csx
+#
+# All division operations use DIVIDE() — no bare "/" operator.
+
+from uuid import UUID
+from typing import Optional
+from sempy._utils._log import log
+import sempy_labs._icons as icons
+from sempy_labs._helper_functions import (
+    resolve_workspace_name_and_id,
+    resolve_dataset_from_report,
+)
+from sempy_labs.tom import connect_semantic_model
+
+# ---------------------------------------------------------------------------
+# Calculation group definition
+# ---------------------------------------------------------------------------
+_TI_CG_NAME = "Time Intelligence"
+
+
+def _build_calc_items(cal: str, date: str) -> list:
+    """
+    Build the list of (name, expression) tuples for all Time Intelligence
+    calculation items.  ``cal`` is the calendar table name and ``date`` is the
+    date column name.
+
+    Always includes: AC, Y-1 … Y-3, YTD, YTD-1, YTD-2,
+    absolute / relative / achievement variances for Y-1/Y-2 and YTD-1/YTD-2.
+    """
+
+    items = [
+        # --- Base periods ---
+        ("AC", "SELECTEDMEASURE()"),
+        (
+            "Y-1",
+            f"CALCULATE(\n"
+            f"    SELECTEDMEASURE(),\n"
+            f"    SAMEPERIODLASTYEAR( '{cal}'[{date}] ),\n"
+            f"    ALL( '{cal}' )\n"
+            f")",
+        ),
+        (
+            "Y-2",
+            f"CALCULATE(\n"
+            f"    SELECTEDMEASURE(),\n"
+            f"    DATEADD( '{cal}'[{date}], -2, YEAR ),\n"
+            f"    ALL( '{cal}' )\n"
+            f")",
+        ),
+        (
+            "Y-3",
+            f"CALCULATE(\n"
+            f"    SELECTEDMEASURE(),\n"
+            f"    DATEADD( '{cal}'[{date}], -3, YEAR ),\n"
+            f"    ALL( '{cal}' )\n"
+            f")",
+        ),
+        # --- YTD ---
+        (
+            "YTD",
+            f"CALCULATE(\n"
+            f"    SELECTEDMEASURE(),\n"
+            f"    DATESYTD( '{cal}'[{date}], \"12/31\" ),\n"
+            f"    ALL( '{cal}' )\n"
+            f")",
+        ),
+        (
+            "YTD-1",
+            f"CALCULATE(\n"
+            f"    SELECTEDMEASURE(),\n"
+            f"    DATEADD( DATESYTD( '{cal}'[{date}], \"12/31\" ), -1, YEAR ),\n"
+            f"    ALL( '{cal}' )\n"
+            f")",
+        ),
+        (
+            "YTD-2",
+            f"CALCULATE(\n"
+            f"    SELECTEDMEASURE(),\n"
+            f"    DATEADD( DATESYTD( '{cal}'[{date}], \"12/31\" ), -2, YEAR ),\n"
+            f"    ALL( '{cal}' )\n"
+            f")",
+        ),
+        # --- Absolute variances ---
+        (
+            "abs. AC vs Y-1",
+            f"VAR AC =\n"
+            f"    TOTALYTD( SELECTEDMEASURE(), DATESYTD( '{cal}'[{date}], \"12/31\" ), ALL( '{cal}' ) )\n"
+            f"VAR Y1 =\n"
+            f"    CALCULATE( SELECTEDMEASURE(), DATEADD( DATESYTD( '{cal}'[{date}], \"12/31\" ), -1, YEAR ), ALL( '{cal}' ) )\n"
+            f"RETURN\n"
+            f"    AC - Y1",
+        ),
+        (
+            "abs. AC vs Y-2",
+            f"VAR AC =\n"
+            f"    TOTALYTD( SELECTEDMEASURE(), DATESYTD( '{cal}'[{date}], \"12/31\" ), ALL( '{cal}' ) )\n"
+            f"VAR Y2 =\n"
+            f"    CALCULATE( SELECTEDMEASURE(), DATEADD( DATESYTD( '{cal}'[{date}], \"12/31\" ), -2, YEAR ), ALL( '{cal}' ) )\n"
+            f"RETURN\n"
+            f"    AC - Y2",
+        ),
+        (
+            "abs. AC vs YTD-1",
+            f"VAR AC =\n"
+            f"    TOTALYTD( SELECTEDMEASURE(), DATESYTD( '{cal}'[{date}], \"12/31\" ), ALL( '{cal}' ) )\n"
+            f"VAR Y1 =\n"
+            f"    CALCULATE( SELECTEDMEASURE(), DATEADD( DATESYTD( '{cal}'[{date}], \"12/31\" ), -1, YEAR ), ALL( '{cal}' ) )\n"
+            f"RETURN\n"
+            f"    AC - Y1",
+        ),
+        (
+            "abs. AC vs YTD-2",
+            f"VAR AC =\n"
+            f"    TOTALYTD( SELECTEDMEASURE(), DATESYTD( '{cal}'[{date}], \"12/31\" ), ALL( '{cal}' ) )\n"
+            f"VAR Y2 =\n"
+            f"    CALCULATE( SELECTEDMEASURE(), DATEADD( DATESYTD( '{cal}'[{date}], \"12/31\" ), -2, YEAR ), ALL( '{cal}' ) )\n"
+            f"RETURN\n"
+            f"    AC - Y2",
+        ),
+        # --- Relative variances (%) ---
+        (
+            "AC vs Y-1",
+            f"VAR AC =\n"
+            f"    TOTALYTD( SELECTEDMEASURE(), DATESYTD( '{cal}'[{date}], \"12/31\" ), ALL( '{cal}' ) )\n"
+            f"VAR Y1 =\n"
+            f"    CALCULATE( SELECTEDMEASURE(), SAMEPERIODLASTYEAR( '{cal}'[{date}] ), ALL( '{cal}' ) )\n"
+            f"RETURN\n"
+            f"    DIVIDE( AC - Y1, Y1 )",
+        ),
+        (
+            "AC vs Y-2",
+            f"VAR AC =\n"
+            f"    TOTALYTD( SELECTEDMEASURE(), DATESYTD( '{cal}'[{date}], \"12/31\" ), ALL( '{cal}' ) )\n"
+            f"VAR Y2 =\n"
+            f"    CALCULATE( SELECTEDMEASURE(), DATEADD( '{cal}'[{date}], -2, YEAR ), ALL( '{cal}' ) )\n"
+            f"RETURN\n"
+            f"    DIVIDE( AC - Y2, Y2 )",
+        ),
+        (
+            "AC vs YTD-1",
+            f"VAR AC =\n"
+            f"    TOTALYTD( SELECTEDMEASURE(), DATESYTD( '{cal}'[{date}], \"12/31\" ), ALL( '{cal}' ) )\n"
+            f"VAR Y1 =\n"
+            f"    CALCULATE( SELECTEDMEASURE(), DATEADD( DATESYTD( '{cal}'[{date}], \"12/31\" ), -1, YEAR ), ALL( '{cal}' ) )\n"
+            f"RETURN\n"
+            f"    DIVIDE( AC - Y1, Y1 )",
+        ),
+        (
+            "AC vs YTD-2",
+            f"VAR AC =\n"
+            f"    TOTALYTD( SELECTEDMEASURE(), DATESYTD( '{cal}'[{date}], \"12/31\" ), ALL( '{cal}' ) )\n"
+            f"VAR Y2 =\n"
+            f"    CALCULATE( SELECTEDMEASURE(), DATEADD( DATESYTD( '{cal}'[{date}], \"12/31\" ), -2, YEAR ), ALL( '{cal}' ) )\n"
+            f"RETURN\n"
+            f"    DIVIDE( AC - Y2, Y2 )",
+        ),
+        # --- Achievement variances ---
+        (
+            "achiev. AC vs Y-1",
+            f"VAR AC =\n"
+            f"    SELECTEDMEASURE()\n"
+            f"VAR Y1 =\n"
+            f"    CALCULATE( SELECTEDMEASURE(), SAMEPERIODLASTYEAR( '{cal}'[{date}] ), ALL( '{cal}' ) )\n"
+            f"RETURN\n"
+            f"    1 - DIVIDE( ( Y1 - AC ), Y1, 0 )",
+        ),
+        (
+            "achiev. AC vs Y-2",
+            f"VAR AC =\n"
+            f"    SELECTEDMEASURE()\n"
+            f"VAR Y2 =\n"
+            f"    CALCULATE( SELECTEDMEASURE(), DATEADD( '{cal}'[{date}], -2, YEAR ), ALL( '{cal}' ) )\n"
+            f"RETURN\n"
+            f"    1 - DIVIDE( ( Y2 - AC ), Y2, 0 )",
+        ),
+        (
+            "achiev. AC vs YTD-1",
+            f"VAR AC =\n"
+            f"    TOTALYTD( SELECTEDMEASURE(), DATESYTD( '{cal}'[{date}], \"12/31\" ), ALL( '{cal}' ) )\n"
+            f"VAR Y1 =\n"
+            f"    CALCULATE( SELECTEDMEASURE(), DATEADD( DATESYTD( '{cal}'[{date}], \"12/31\" ), -1, YEAR ), ALL( '{cal}' ) )\n"
+            f"RETURN\n"
+            f"    1 - DIVIDE( ( Y1 - AC ), Y1, 0 )",
+        ),
+        (
+            "achiev. AC vs YTD-2",
+            f"VAR AC =\n"
+            f"    TOTALYTD( SELECTEDMEASURE(), DATESYTD( '{cal}'[{date}], \"12/31\" ), ALL( '{cal}' ) )\n"
+            f"VAR Y2 =\n"
+            f"    CALCULATE( SELECTEDMEASURE(), DATEADD( DATESYTD( '{cal}'[{date}], \"12/31\" ), -2, YEAR ), ALL( '{cal}' ) )\n"
+            f"RETURN\n"
+            f"    1 - DIVIDE( ( Y2 - AC ), Y2, 0 )",
+        ),
+    ]
+
+    return items
+
+
+@log
+def add_calc_group_time_intelligence(
+    report: str | UUID,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+) -> None:
+    """
+    Checks whether a "Time Intelligence" calculation group (or any table whose
+    name contains "time intelligence") exists in the semantic model that backs
+    the given report.  If none is found, locates the calendar table
+    (DataCategory = "Time") and its key date column, then creates a calculation
+    group with AC, Y-1/Y-2/Y-3, YTD/YTD-1/YTD-2, absolute/relative/achievement
+    variances.
+
+    Also sets DiscourageImplicitMeasures to True (required for calculation
+    groups).
+
+    All division operations use ``DIVIDE()`` — no bare ``/`` operators.
+
+    Parameters
+    ----------
+    report : str | uuid.UUID
+        Name or ID of the Power BI report whose semantic model will be checked.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+        Defaults to None which resolves to the workspace of the attached lakehouse
+        or if no lakehouse attached, resolves to the workspace of the notebook.
+    scan_only : bool, default=False
+        If True, only reports whether a Time Intelligence calculation group exists
+        without making any changes.
+
+    Returns
+    -------
+    None
+    """
+
+    workspace_name, workspace_id = resolve_workspace_name_and_id(workspace)
+
+    dataset_id, dataset_name, dataset_workspace_id, dataset_workspace_name = (
+        resolve_dataset_from_report(report=report, workspace=workspace_id)
+    )
+
+    with connect_semantic_model(
+        dataset=dataset_id,
+        readonly=scan_only,
+        workspace=dataset_workspace_id,
+    ) as tom:
+
+        # Fuzzy match: any table whose name contains "time intelligence"
+        ti_tables = [
+            t.Name for t in tom.model.Tables if "time intelligence" in t.Name.lower()
+        ]
+
+        if ti_tables:
+            table_list = ", ".join(f"'{t}'" for t in ti_tables)
+            if scan_only:
+                print(
+                    f"{icons.green_dot} A Time Intelligence calculation group "
+                    f"already exists: {table_list} — no action needed."
+                )
+            else:
+                print(
+                    f"{icons.info} A Time Intelligence calculation group "
+                    f"already exists: {table_list}. Skipping creation."
+                )
+            return
+
+        # --- Locate the calendar table (DataCategory = "Time") ---
+        calendar_table = None
+        for t in tom.model.Tables:
+            if t.DataCategory == "Time":
+                calendar_table = t
+                break
+
+        if calendar_table is None:
+            if scan_only:
+                print(
+                    f"{icons.yellow_dot} No table containing 'Time Intelligence' "
+                    f"found in '{dataset_name}'. A '{_TI_CG_NAME}' "
+                    f"calculation group would be added."
+                )
+                print(
+                    f"{icons.yellow_dot} However, no calendar table "
+                    f"(DataCategory = 'Time') was found. Please add one first "
+                    f"(e.g. via the Calendar Table fixer)."
+                )
+            else:
+                print(
+                    f"{icons.red_dot} Cannot create Time Intelligence calculation "
+                    f"group: no calendar table (DataCategory = 'Time') found in "
+                    f"'{dataset_name}'. Add a calendar table first."
+                )
+            return
+
+        cal_name = calendar_table.Name
+
+        # Find the key (date) column
+        date_column = None
+        for c in calendar_table.Columns:
+            if c.IsKey:
+                date_column = c.Name
+                break
+
+        if date_column is None:
+            # Fallback: look for a column named "Date"
+            for c in calendar_table.Columns:
+                if c.Name.lower() == "date":
+                    date_column = c.Name
+                    break
+
+        if date_column is None:
+            msg = (
+                f"Cannot determine the date column in '{cal_name}'. "
+                f"Please mark a date column as IsKey or name it 'Date'."
+            )
+            if scan_only:
+                print(f"{icons.yellow_dot} {msg}")
+            else:
+                print(f"{icons.red_dot} {msg}")
+            return
+
+        # No TI table found — report or create
+        if scan_only:
+            print(
+                f"{icons.yellow_dot} No table containing 'Time Intelligence' "
+                f"found in '{dataset_name}'. A '{_TI_CG_NAME}' calculation "
+                f"group would be added using '{cal_name}'[{date_column}]."
+            )
+            return
+
+        # --- Fix mode: create the calculation group ---
+        print(
+            f"{icons.in_progress} Adding '{_TI_CG_NAME}' calculation group "
+            f"to '{dataset_name}' using '{cal_name}'[{date_column}]..."
+        )
+
+        # 1. Determine a unique precedence (max existing + 10)
+        existing_precedences = [
+            t.CalculationGroup.Precedence
+            for t in tom.model.Tables
+            if t.CalculationGroup is not None
+        ]
+        precedence = max(existing_precedences, default=-10) + 10
+
+        # 2. Create the calculation group (also sets DiscourageImplicitMeasures)
+        tom.add_calculation_group(
+            name=_TI_CG_NAME,
+            precedence=precedence,
+        )
+
+        # Rename the default "Name" column to match the calc group name
+        tom.model.Tables[_TI_CG_NAME].Columns["Name"].Name = _TI_CG_NAME
+
+        # 3. Build and add all calculation items
+        calc_items = _build_calc_items(cal=cal_name, date=date_column)
+
+        for ordinal, (item_name, expression) in enumerate(calc_items):
+            tom.add_calculation_item(
+                table_name=_TI_CG_NAME,
+                calculation_item_name=item_name,
+                expression=expression,
+                ordinal=ordinal,
+            )
+
+        print(
+            f"{icons.green_dot} '{_TI_CG_NAME}' calculation group added "
+            f"successfully to '{dataset_name}' with {len(calc_items)} items."
+        )
+
+
+# Sample usage:
+# add_calc_group_time_intelligence(report="My Report")
+# add_calc_group_time_intelligence(report="My Report", workspace="My Workspace")
+# add_calc_group_time_intelligence(report="My Report", scan_only=True)

--- a/src/sempy_labs/semantic_model/_Add_CalcGroup_Units.py
+++ b/src/sempy_labs/semantic_model/_Add_CalcGroup_Units.py
@@ -1,0 +1,185 @@
+# Add "Units" Calculation Group to Semantic Model
+# Based on: https://github.com/KornAlexander/PBI-Tools/.../1. Units.csx
+
+from uuid import UUID
+from typing import Optional
+from sempy._utils._log import log
+import sempy_labs._icons as icons
+from sempy_labs._helper_functions import (
+    resolve_workspace_name_and_id,
+    resolve_dataset_from_report,
+)
+from sempy_labs.tom import connect_semantic_model
+
+# ---------------------------------------------------------------------------
+# Calculation group definition
+# ---------------------------------------------------------------------------
+_UNITS_CG_NAME = "Units"
+
+# Each item: (name, DAX expression)
+# The expressions skip measures whose name contains "%" or "ratio" to avoid
+# dividing percentage/ratio measures.
+_UNITS_CALC_ITEMS = [
+    (
+        "Thousand",
+        (
+            "IF(\n"
+            "    ISNUMBER( SELECTEDMEASURE() ),\n"
+            "    IF(\n"
+            "        NOT(\n"
+            '            CONTAINSSTRING( SELECTEDMEASURENAME(), "%" )\n'
+            '                || CONTAINSSTRING( SELECTEDMEASURENAME(), "ratio" )\n'
+            "        ),\n"
+            "        DIVIDE( SELECTEDMEASURE(), 1000 ),\n"
+            "        SELECTEDMEASURE()\n"
+            "    ),\n"
+            "    SELECTEDMEASURE()\n"
+            ")"
+        ),
+    ),
+    (
+        "Million",
+        (
+            "IF(\n"
+            "    ISNUMBER( SELECTEDMEASURE() ),\n"
+            "    IF(\n"
+            "        NOT(\n"
+            '            CONTAINSSTRING( SELECTEDMEASURENAME(), "%" )\n'
+            '                || CONTAINSSTRING( SELECTEDMEASURENAME(), "ratio" )\n'
+            "        ),\n"
+            "        DIVIDE( SELECTEDMEASURE(), 1000000 ),\n"
+            "        SELECTEDMEASURE()\n"
+            "    ),\n"
+            "    SELECTEDMEASURE()\n"
+            ")"
+        ),
+    ),
+]
+
+
+@log
+def add_calc_group_units(
+    report: str | UUID,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+) -> None:
+    """
+    Checks whether a "Units" calculation group (or any table whose name
+    contains "unit") exists in the semantic model that backs the given report.
+    If none is found, creates a calculation group with "Thousand" and "Million"
+    items that divide numeric measures accordingly (skipping percentage / ratio
+    measures).
+
+    Also sets DiscourageImplicitMeasures to True (required for calculation
+    groups).
+
+    Note: Calculation groups can have a performance impact when used inside
+    reports.  Use them judiciously — especially with large models or complex
+    measure chains.
+
+    Parameters
+    ----------
+    report : str | uuid.UUID
+        Name or ID of the Power BI report whose semantic model will be checked.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+        Defaults to None which resolves to the workspace of the attached lakehouse
+        or if no lakehouse attached, resolves to the workspace of the notebook.
+    scan_only : bool, default=False
+        If True, only reports whether a Units calculation group exists without
+        making any changes.
+
+    Returns
+    -------
+    None
+    """
+
+    workspace_name, workspace_id = resolve_workspace_name_and_id(workspace)
+
+    dataset_id, dataset_name, dataset_workspace_id, dataset_workspace_name = (
+        resolve_dataset_from_report(report=report, workspace=workspace_id)
+    )
+
+    with connect_semantic_model(
+        dataset=dataset_id,
+        readonly=scan_only,
+        workspace=dataset_workspace_id,
+    ) as tom:
+
+        # Fuzzy match: any table whose name contains "unit"
+        unit_tables = [t.Name for t in tom.model.Tables if "unit" in t.Name.lower()]
+
+        if unit_tables:
+            table_list = ", ".join(f"'{t}'" for t in unit_tables)
+            if scan_only:
+                print(
+                    f"{icons.green_dot} A Units calculation group already exists: "
+                    f"{table_list} — no action needed."
+                )
+            else:
+                print(
+                    f"{icons.info} A Units calculation group already exists: "
+                    f"{table_list}. Skipping creation."
+                )
+            return
+
+        # No units table found
+        if scan_only:
+            print(
+                f"{icons.yellow_dot} No table containing 'Unit' found in "
+                f"'{dataset_name}'. A '{_UNITS_CG_NAME}' calculation group "
+                f"would be added."
+            )
+            print(
+                f"{icons.info} Note: Calculation groups can have a performance "
+                f"impact when used within reports."
+            )
+            return
+
+        # --- Fix mode: create the calculation group ---
+        print(
+            f"{icons.in_progress} Adding '{_UNITS_CG_NAME}' calculation group "
+            f"to '{dataset_name}' in '{dataset_workspace_name}'..."
+        )
+        print(
+            f"{icons.info} Note: Calculation groups can have a performance "
+            f"impact when used within reports."
+        )
+
+        # 1. Determine a unique precedence (max existing + 10)
+        existing_precedences = [
+            t.CalculationGroup.Precedence
+            for t in tom.model.Tables
+            if t.CalculationGroup is not None
+        ]
+        precedence = max(existing_precedences, default=-10) + 10
+
+        # 2. Create the calculation group (also sets DiscourageImplicitMeasures)
+        tom.add_calculation_group(
+            name=_UNITS_CG_NAME,
+            precedence=precedence,
+        )
+
+        # Rename the default "Name" column to match the calc group name
+        tom.model.Tables[_UNITS_CG_NAME].Columns["Name"].Name = _UNITS_CG_NAME
+
+        # 3. Add calculation items
+        for ordinal, (item_name, expression) in enumerate(_UNITS_CALC_ITEMS):
+            tom.add_calculation_item(
+                table_name=_UNITS_CG_NAME,
+                calculation_item_name=item_name,
+                expression=expression,
+                ordinal=ordinal,
+            )
+
+        print(
+            f"{icons.green_dot} '{_UNITS_CG_NAME}' calculation group added "
+            f"successfully to '{dataset_name}' with {len(_UNITS_CALC_ITEMS)} items "
+            f"(Thousand, Million)."
+        )
+
+
+# Sample usage:
+# add_calc_group_units(report="My Report")
+# add_calc_group_units(report="My Report", workspace="My Workspace")
+# add_calc_group_units(report="My Report", scan_only=True)

--- a/src/sempy_labs/semantic_model/_Add_CalculatedTable_Calendar.py
+++ b/src/sempy_labs/semantic_model/_Add_CalculatedTable_Calendar.py
@@ -1,0 +1,302 @@
+# Add Calculated Calendar Table to Semantic Model
+# %pip install semantic-link-labs
+
+from uuid import UUID
+from typing import Optional
+from sempy._utils._log import log
+import sempy_labs._icons as icons
+from sempy_labs._helper_functions import (
+    resolve_workspace_name_and_id,
+    resolve_dataset_from_report,
+)
+from sempy_labs.tom import connect_semantic_model
+from sempy_labs._refresh_semantic_model import refresh_semantic_model
+
+# ---------------------------------------------------------------------------
+# The full DAX expression for the calculated calendar table.
+# Source: https://community.fabric.microsoft.com/t5/TMDL-Gallery/Calc-Table-Calendar/td-p/4798025
+# ---------------------------------------------------------------------------
+_CALENDAR_DAX = """
+VAR Today = TODAY()
+VAR MonthStartFiscalYear = 10
+RETURN
+    ADDCOLUMNS(
+        CALENDARAUTO(),
+        "Year", YEAR([Date]),
+        "Quarter", "Q " & QUARTER([Date]),
+        "Month", MONTH([Date]),
+        "Month (MMM)", FORMAT([Date], "MMM"),
+        "Day", DAY([Date]),
+        "Fiscal Year", YEAR([Date]) + IF(MONTH([Date]) >= MonthStartFiscalYear, 1, 0),
+        "End of Month", EOMONTH([Date], 0),
+        "Week of Year", WEEKNUM([Date]),
+        "Weekday", WEEKDAY([Date]),
+        "Is Current or Past Month", IF([Date] <= EOMONTH(TODAY(), 0), "Yes", "No"),
+        "Is Before This Month", FORMAT([Date],"YYYYMM") < FORMAT(Today,"YYYYMM"),
+        "Is Current Fiscal Year",
+            VAR CurrentFiscalYear = YEAR(Today) + IF(MONTH(Today) >= MonthStartFiscalYear, 1, 0)
+            RETURN YEAR([Date]) + IF(MONTH([Date]) >= MonthStartFiscalYear, 1, 0) = CurrentFiscalYear,
+        "Is Previous Fiscal Year",
+            VAR CurrentFiscalYear = YEAR(Today) + IF(MONTH(Today) >= MonthStartFiscalYear, 1, 0)
+            RETURN YEAR([Date]) + IF(MONTH([Date]) >= MonthStartFiscalYear, 1, 0) = CurrentFiscalYear - 1,
+        "Is Current Calendar Year", YEAR([Date]) = YEAR(Today),
+        "Is Previous Calendar Year", YEAR([Date]) = YEAR(Today) - 1,
+        "Is Current Month",
+            YEAR([Date]) = YEAR(Today) && MONTH([Date]) = MONTH(Today),
+        "Is Previous Month",
+            VAR PrevMonthYear = IF(MONTH(Today) = 1, YEAR(Today) - 1, YEAR(Today))
+            VAR PrevMonth = IF(MONTH(Today) = 1, 12, MONTH(Today) - 1)
+            RETURN YEAR([Date]) = PrevMonthYear && MONTH([Date]) = PrevMonth,
+        "Month Key", YEAR([Date]) * 100 + MONTH([Date]),
+        "Relative Month", (YEAR([Date]) - YEAR(Today)) * 12 + (MONTH([Date]) - MONTH(Today))
+    )
+""".strip()
+
+# Table and column names matching the TMDL definition
+_CAL_TABLE_NAME = "CalcCalendar"
+
+# Boolean format string matching the original TMDL
+_BOOL_FMT = '"""TRUE"";""TRUE"";""FALSE"""'
+
+# Column definitions:
+#   (column_name, source_column, data_type, format_string, is_key, hidden, summarize_by, display_folder)
+_COLUMNS = [
+    ("Date",                        "CalcCalendar.[Date]",                        "DateTime", "Short Date",    True,  False, "None",    "1. Favorites"),
+    ("Month",                       "CalcCalendar.[Month]",                       "Int64",    "0",             False, False, "Sum",     "2. Calendar Date\\2. Number Columns"),
+    ("Fiscal Year",                 "CalcCalendar.[Fiscal Year]",                 "Int64",    "0",             False, False, "Sum",     "3. Fiscal Date\\2. Numbers;1. Favorites"),
+    ("Year",                        "CalcCalendar.[Year]",                        "Int64",    "0",             False, False, "Sum",     "2. Calendar Date\\2. Number Columns;1. Favorites"),
+    ("Month (MMM)",                 "CalcCalendar.[Month (MMM)]",                 "String",   None,            False, False, "None",    "2. Calendar Date\\3. Text Columns;1. Favorites"),
+    ("Day",                         "CalcCalendar.[Day]",                         "Int64",    "0",             False, False, "Sum",     "2. Calendar Date\\2. Number Columns"),
+    ("Is Before This Month",        "CalcCalendar.[Is Before This Month]",        "Boolean",  _BOOL_FMT,       False, False, "None",    "4. Flags"),
+    ("Is Current Fiscal Year",      "CalcCalendar.[Is Current Fiscal Year]",      "Boolean",  _BOOL_FMT,       False, False, "None",    "4. Flags"),
+    ("Is Previous Fiscal Year",     "CalcCalendar.[Is Previous Fiscal Year]",     "Boolean",  _BOOL_FMT,       False, False, "None",    "4. Flags"),
+    ("Is Current Calendar Year",    "CalcCalendar.[Is Current Calendar Year]",    "Boolean",  _BOOL_FMT,       False, False, "None",    "4. Flags"),
+    ("Is Previous Calendar Year",   "CalcCalendar.[Is Previous Calendar Year]",   "Boolean",  _BOOL_FMT,       False, False, "None",    "4. Flags"),
+    ("Is Current Month",            "CalcCalendar.[Is Current Month]",            "Boolean",  _BOOL_FMT,       False, False, "None",    "4. Flags"),
+    ("Is Previous Month",           "CalcCalendar.[Is Previous Month]",           "Boolean",  _BOOL_FMT,       False, False, "None",    "4. Flags"),
+    ("Year Month Key",              "CalcCalendar.[Month Key]",                   "Int64",    "0",             False, False, "Count",   "2. Calendar Date\\2. Number Columns"),
+    ("Relative Month",              "CalcCalendar.[Relative Month]",              "Int64",    "0",             False, False, "Sum",     "4. Flags"),
+    ("Quarter",                     "CalcCalendar.[Quarter]",                     "String",   None,            False, False, "None",    "2. Calendar Date\\3. Text Columns"),
+    ("End of Month",                "CalcCalendar.[End of Month]",                "DateTime", "General Date",  False, False, "None",    "2. Calendar Date\\2. Number Columns"),
+    ("Week of Year",                "CalcCalendar.[Week of Year]",                "Int64",    "0",             False, False, "Sum",     "2. Calendar Date\\2. Number Columns"),
+    ("Weekday",                     "CalcCalendar.[Weekday]",                     "Int64",    "0",             False, False, "Sum",     "2. Calendar Date\\2. Number Columns"),
+    ("Is Current or Past Months",   "CalcCalendar.[Is Current or Past Month]",    "String",   None,            False, False, "None",    "4. Flags"),
+]
+
+# Sort-by-column mappings: (column_name, sort_by_column_name)
+_SORT_BY = [
+    ("Month (MMM)", "Month"),
+]
+
+# Hierarchy definitions: (hierarchy_name, [columns], [levels], display_folder)
+_HIERARCHIES = [
+    ("Date Hierarchy",        ["Year", "Quarter", "Month", "Day"],                None, "2. Calendar Date\\1. Hierarchy"),
+    ("Fiscal Date Hierarchy", ["Fiscal Year", "Quarter", "Month", "Day"],         None, "3. Fiscal Date\\1. Hierarchy"),
+    ("Calendar Hierarchy",    ["Year", "Month (MMM)", "Week of Year", "Weekday"], None, "1. Favorites"),
+]
+
+
+@log
+def add_calculated_calendar(
+    report: str | UUID,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+    relationships: Optional[list] = None,
+) -> None:
+    """
+    Checks whether a calendar table (DataCategory = 'Time') exists in the
+    semantic model that backs the given report. If none is found, adds the
+    CalcCalendar calculated table with a full set of date-intelligence columns
+    and hierarchies. Optionally creates relationships to Date/DateTime columns.
+
+    Parameters
+    ----------
+    report : str | uuid.UUID
+        Name or ID of the Power BI report whose semantic model will be checked.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+        Defaults to None which resolves to the workspace of the attached lakehouse
+        or if no lakehouse attached, resolves to the workspace of the notebook.
+    scan_only : bool, default=False
+        If True, only reports whether a Time-category table exists without
+        making any changes.
+    relationships : list, default=None
+        List of (from_table, from_column, calendar_column) tuples specifying
+        relationships to create from fact tables to the calendar table.
+        If None, auto-detects all Date/DateTime columns not already in a
+        relationship and creates Many→One relationships to CalcCalendar[Date].
+
+    Returns
+    -------
+    None
+    """
+
+    (workspace_name, workspace_id) = resolve_workspace_name_and_id(workspace)
+
+    # Resolve the semantic model behind this report
+    dataset_id, dataset_name, dataset_workspace_id, dataset_workspace_name = (
+        resolve_dataset_from_report(report=report, workspace=workspace_id)
+    )
+
+    with connect_semantic_model(
+        dataset=dataset_id,
+        readonly=scan_only,
+        workspace=dataset_workspace_id,
+    ) as tom:
+
+        # Check for any table with DataCategory == "Time"
+        time_tables = [
+            t.Name for t in tom.model.Tables if t.DataCategory == "Time"
+        ]
+
+        if time_tables:
+            table_list = ", ".join(f"'{t}'" for t in time_tables)
+            if scan_only:
+                print(
+                    f"{icons.green_dot} Calendar table already exists: {table_list} "
+                    f"(DataCategory = Time) — no action needed."
+                )
+            else:
+                print(
+                    f"{icons.info} Calendar table already exists: {table_list} "
+                    f"(DataCategory = Time). Skipping creation."
+                )
+            return
+
+        # No Time-category table found
+        if scan_only:
+            print(
+                f"{icons.yellow_dot} No table with DataCategory 'Time' found in "
+                f"'{dataset_name}'. A CalcCalendar table would be added."
+            )
+            return
+
+        # --- Fix mode: create the calculated table ---
+        print(
+            f"{icons.in_progress} Adding CalcCalendar table to "
+            f"'{dataset_name}' in '{dataset_workspace_name}'..."
+        )
+
+        # 1. Add the calculated table
+        tom.add_calculated_table(
+            name=_CAL_TABLE_NAME,
+            expression=_CALENDAR_DAX,
+            data_category="Time",
+        )
+
+        # 2. Add all columns (with display folders)
+        for col_name, source_col, data_type, fmt, is_key, hidden, summarize, folder in _COLUMNS:
+            tom.add_calculated_table_column(
+                table_name=_CAL_TABLE_NAME,
+                column_name=col_name,
+                source_column=source_col,
+                data_type=data_type,
+                format_string=fmt,
+                hidden=hidden,
+                key=is_key,
+                summarize_by=summarize,
+                display_folder=folder,
+            )
+
+        # 3. Mark as date table (sets DataCategory=Time + IsKey on Date column)
+        tom.mark_as_date_table(
+            table_name=_CAL_TABLE_NAME,
+            column_name="Date",
+        )
+
+        # 4. Intermediate save — server must assign column IDs before
+        #    hierarchies can reference them.
+        tom.model.SaveChanges()
+
+        # 4b. Re-apply display folders AFTER SaveChanges — the server
+        #     regenerates CalculatedTableColumn objects during save and
+        #     may drop display folders set before the round-trip.
+        cal_table = tom.model.Tables.Find(_CAL_TABLE_NAME)
+        if cal_table is not None:
+            for col_name, _sc, _dt, _fmt, _ik, _hid, _sum, folder in _COLUMNS:
+                col_obj = cal_table.Columns.Find(col_name)
+                if col_obj is not None and folder:
+                    col_obj.DisplayFolder = folder
+
+        # 5. Set sort-by-column relationships
+        for col_name, sort_col in _SORT_BY:
+            tom.set_sort_by_column(
+                table_name=_CAL_TABLE_NAME,
+                column_name=col_name,
+                sort_by_column=sort_col,
+            )
+
+        # 6. Add hierarchies (with display folders)
+        for hier_name, columns, levels, folder in _HIERARCHIES:
+            tom.add_hierarchy(
+                table_name=_CAL_TABLE_NAME,
+                hierarchy_name=hier_name,
+                columns=columns,
+                levels=levels,
+            )
+            # Set display folder on the hierarchy object (use .Find() for pythonnet safety)
+            if cal_table is not None:
+                hier_obj = cal_table.Hierarchies.Find(hier_name)
+                if hier_obj is not None:
+                    hier_obj.DisplayFolder = folder
+
+        # 7. Create relationships to Date/DateTime columns
+        #    If relationships=None, auto-detect all Date/DateTime columns not already in a relationship.
+        if relationships is None:
+            relationships = []
+            existing_rels = set()
+            for r in tom.model.Relationships:
+                existing_rels.add((str(r.FromColumn.Table.Name), str(r.FromColumn.Name)))
+            for t in tom.model.Tables:
+                if t.Name == _CAL_TABLE_NAME:
+                    continue
+                for c in t.Columns:
+                    dt = str(c.DataType)
+                    if dt in ("DateTime", "DateTimeOffset"):
+                        if (t.Name, c.Name) not in existing_rels:
+                            relationships.append((t.Name, c.Name, "Date"))
+
+        rels_created = 0
+        if relationships:
+            for from_table, from_column, cal_column in relationships:
+                try:
+                    tom.add_relationship(
+                        from_table=from_table,
+                        from_column=from_column,
+                        to_table=_CAL_TABLE_NAME,
+                        to_column=cal_column,
+                        from_cardinality="Many",
+                        to_cardinality="One",
+                    )
+                    rels_created += 1
+                    print(
+                        f"{icons.green_dot} Created relationship: "
+                        f"'{from_table}'[{from_column}] → '{_CAL_TABLE_NAME}'[{cal_column}]"
+                    )
+                except Exception as e:
+                    print(
+                        f"{icons.yellow_dot} Could not create relationship "
+                        f"'{from_table}'[{from_column}] → '{_CAL_TABLE_NAME}'[{cal_column}]: {e}"
+                    )
+
+        rel_msg = f" and {rels_created} relationship(s)" if rels_created else ""
+        print(
+            f"{icons.green_dot} CalcCalendar table added successfully to "
+            f"'{dataset_name}' with {len(_COLUMNS)} columns, "
+            f"{len(_HIERARCHIES)} hierarchies{rel_msg}."
+        )
+
+    # Refresh to populate the calculated table data
+    print(f"{icons.in_progress} Refreshing CalcCalendar table...")
+    refresh_semantic_model(
+        dataset=dataset_id,
+        tables=[_CAL_TABLE_NAME],
+        refresh_type="calculate",
+        workspace=dataset_workspace_id,
+    )
+    print(f"{icons.green_dot} CalcCalendar table refreshed.")
+
+# Sample usage:
+# add_calculated_calendar(report="My Report")
+# add_calculated_calendar(report="My Report", workspace="My Workspace")
+# add_calculated_calendar(report="My Report", scan_only=True)

--- a/src/sempy_labs/semantic_model/_Add_CalculatedTable_MeasureTable.py
+++ b/src/sempy_labs/semantic_model/_Add_CalculatedTable_MeasureTable.py
@@ -1,0 +1,121 @@
+# Add Empty "Measure" Calculated Table to Semantic Model
+# Based on: https://github.com/KornAlexander/PBI-Tools/.../2. Create Empty Measure Table (TE3).csx
+
+from uuid import UUID
+from typing import Optional
+from sempy._utils._log import log
+import sempy_labs._icons as icons
+from sempy_labs._helper_functions import (
+    resolve_workspace_name_and_id,
+    resolve_dataset_from_report,
+)
+from sempy_labs.tom import connect_semantic_model
+
+# ---------------------------------------------------------------------------
+# Table definition
+# ---------------------------------------------------------------------------
+_MT_TABLE_NAME = "Measure"
+
+# A single-row, zero-column calculated table — the lightest possible placeholder.
+_CALC_EXPRESSION = "{0}"
+
+
+@log
+def add_measure_table(
+    report: str | UUID,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+) -> None:
+    """
+    Checks whether a "Measure" table (or any table whose name contains
+    "measure") exists in the semantic model that backs the given report.
+    If none is found, adds an empty calculated table named "Measure" that
+    serves as a centralized container for measures.  The auto-generated
+    column is hidden.
+
+    Parameters
+    ----------
+    report : str | uuid.UUID
+        Name or ID of the Power BI report whose semantic model will be checked.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+        Defaults to None which resolves to the workspace of the attached lakehouse
+        or if no lakehouse attached, resolves to the workspace of the notebook.
+    scan_only : bool, default=False
+        If True, only reports whether a Measure table exists without
+        making any changes.
+
+    Returns
+    -------
+    None
+    """
+
+    workspace_name, workspace_id = resolve_workspace_name_and_id(workspace)
+
+    dataset_id, dataset_name, dataset_workspace_id, dataset_workspace_name = (
+        resolve_dataset_from_report(report=report, workspace=workspace_id)
+    )
+
+    with connect_semantic_model(
+        dataset=dataset_id,
+        readonly=scan_only,
+        workspace=dataset_workspace_id,
+    ) as tom:
+
+        # Fuzzy match: any table whose name contains "measure"
+        measure_tables = [
+            t.Name for t in tom.model.Tables if "measure" in t.Name.lower()
+        ]
+
+        if measure_tables:
+            table_list = ", ".join(f"'{t}'" for t in measure_tables)
+            if scan_only:
+                print(
+                    f"{icons.green_dot} A Measure table already exists: "
+                    f"{table_list} — no action needed."
+                )
+            else:
+                print(
+                    f"{icons.info} A Measure table already exists: "
+                    f"{table_list}. Skipping creation."
+                )
+            return
+
+        # No measure table found
+        if scan_only:
+            print(
+                f"{icons.yellow_dot} No table containing 'Measure' found in "
+                f"'{dataset_name}'. A '{_MT_TABLE_NAME}' table would be added."
+            )
+            return
+
+        # --- Fix mode: create the calculated table ---
+        print(
+            f"{icons.in_progress} Adding '{_MT_TABLE_NAME}' table to "
+            f"'{dataset_name}' in '{dataset_workspace_name}'..."
+        )
+
+        # 1. Add the calculated table
+        tom.add_calculated_table(
+            name=_MT_TABLE_NAME,
+            expression=_CALC_EXPRESSION,
+        )
+
+        # 2. Save so the auto-generated column materialises
+        tom.model.SaveChanges()
+
+        # 3. Hide the auto-generated column (typically named "Value")
+        for col in tom.model.Tables[_MT_TABLE_NAME].Columns:
+            col.IsHidden = True
+
+        print(
+            f"{icons.green_dot} '{_MT_TABLE_NAME}' table added successfully to "
+            f"'{dataset_name}'. Move your measures into this table to keep "
+            f"the model organised."
+        )
+
+
+# Sample usage:
+# add_measure_table(report="My Report")
+# add_measure_table(report="My Report", workspace="My Workspace")
+# add_measure_table(report="My Report", scan_only=True)

--- a/src/sempy_labs/semantic_model/_Add_Table_LastRefresh.py
+++ b/src/sempy_labs/semantic_model/_Add_Table_LastRefresh.py
@@ -1,0 +1,154 @@
+# Add "Last Refresh" Table to Semantic Model
+# Based on: https://github.com/KornAlexander/PBI-Tools/.../Last Refresh.tmdl
+
+from uuid import UUID
+from typing import Optional
+from sempy._utils._log import log
+import sempy_labs._icons as icons
+from sempy_labs._helper_functions import (
+    resolve_workspace_name_and_id,
+    resolve_dataset_from_report,
+)
+from sempy_labs.tom import connect_semantic_model
+
+# ---------------------------------------------------------------------------
+# Table / column / measure definitions derived from the TMDL template.
+# ---------------------------------------------------------------------------
+_LR_TABLE_NAME = "Last Refresh"
+
+_M_EXPRESSION = (
+    "let\n"
+    '    #"Today" = #table({"Last Refreshes"}, '
+    "{{DateTime.From(DateTime.LocalNow())}})\n"
+    "in\n"
+    '    #"Today"'
+)
+
+_MEASURE_NAME = "Last Refresh Measure"
+_MEASURE_EXPRESSION = "\"Last Refresh: \" & MAX('Last Refresh'[Last Refreshes])"
+_MEASURE_DISPLAY_FOLDER = "Meta"
+
+
+@log
+def add_last_refresh_table(
+    report: str | UUID,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+) -> None:
+    """
+    Checks whether a "Last Refresh" table (or any table whose name contains
+    "refresh") exists in the semantic model that backs the given report.
+    If none is found, adds a small M-partition table that records the timestamp
+    of every data refresh together with a convenience measure.
+
+    Parameters
+    ----------
+    report : str | uuid.UUID
+        Name or ID of the Power BI report whose semantic model will be checked.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+        Defaults to None which resolves to the workspace of the attached lakehouse
+        or if no lakehouse attached, resolves to the workspace of the notebook.
+    scan_only : bool, default=False
+        If True, only reports whether a "Last Refresh" table exists without
+        making any changes.
+
+    Returns
+    -------
+    None
+    """
+
+    workspace_name, workspace_id = resolve_workspace_name_and_id(workspace)
+
+    dataset_id, dataset_name, dataset_workspace_id, dataset_workspace_name = (
+        resolve_dataset_from_report(report=report, workspace=workspace_id)
+    )
+
+    with connect_semantic_model(
+        dataset=dataset_id,
+        readonly=scan_only,
+        workspace=dataset_workspace_id,
+    ) as tom:
+
+        # Fuzzy match: any table whose name contains "refresh"
+        refresh_tables = [
+            t.Name for t in tom.model.Tables if "refresh" in t.Name.lower()
+        ]
+
+        if refresh_tables:
+            table_list = ", ".join(f"'{t}'" for t in refresh_tables)
+            if scan_only:
+                print(
+                    f"{icons.green_dot} A refresh table already exists: {table_list} "
+                    f"— no action needed."
+                )
+            else:
+                print(
+                    f"{icons.info} A refresh table already exists: {table_list}. "
+                    f"Skipping creation."
+                )
+            return
+
+        # No refresh table found
+        if scan_only:
+            print(
+                f"{icons.yellow_dot} No table containing 'Refresh' found in "
+                f"'{dataset_name}'. A '{_LR_TABLE_NAME}' table would be added."
+            )
+            return
+
+        # --- Fix mode: create the table ---
+        print(
+            f"{icons.in_progress} Adding '{_LR_TABLE_NAME}' table to "
+            f"'{dataset_name}' in '{dataset_workspace_name}'..."
+        )
+
+        # 1. Create the table (hidden — only the measure is user-facing)
+        tom.add_table(name=_LR_TABLE_NAME, hidden=True)
+
+        # 2. Add M-partition
+        tom.add_m_partition(
+            table_name=_LR_TABLE_NAME,
+            partition_name=_LR_TABLE_NAME,
+            expression=_M_EXPRESSION,
+            mode="Import",
+        )
+
+        # 3. Add the data column
+        tom.add_data_column(
+            table_name=_LR_TABLE_NAME,
+            column_name="Last Refreshes",
+            source_column="Last Refreshes",
+            data_type="String",
+            hidden=False,
+            summarize_by="None",
+        )
+
+        # 4. Add the measure — prefer the "Measure" table if it exists
+        measure_tables = [
+            t.Name for t in tom.model.Tables if "measure" in t.Name.lower()
+        ]
+        measure_target = measure_tables[0] if measure_tables else _LR_TABLE_NAME
+
+        tom.add_measure(
+            table_name=measure_target,
+            measure_name=_MEASURE_NAME,
+            expression=_MEASURE_EXPRESSION,
+            display_folder=_MEASURE_DISPLAY_FOLDER,
+        )
+
+        target_info = (
+            f" (measure placed in '{measure_target}')"
+            if measure_target != _LR_TABLE_NAME
+            else ""
+        )
+        print(
+            f"{icons.green_dot} '{_LR_TABLE_NAME}' table added successfully to "
+            f"'{dataset_name}' with 1 column and 1 measure{target_info}."
+        )
+
+
+# Sample usage:
+# add_last_refresh_table(report="My Report")
+# add_last_refresh_table(report="My Report", workspace="My Workspace")
+# add_last_refresh_table(report="My Report", scan_only=True)


### PR DESCRIPTION
## Add Semantic Model Components

Adds common building blocks to a semantic model: a calculated calendar table with date intelligence columns, an empty measure table for centralizing measures, a Last Refresh table with an M partition that captures the refresh timestamp, and two calculation groups (Units for thousand/million formatting, Time Intelligence for YTD/QTD/MTD/PY/etc.).

### Functions Added

| Function | Description |
|----------|-------------|
| `add_calculated_calendar(report, workspace=None, scan_only=False, relationships=None)` | Adds a calculated calendar table (DataCategory='Time') with year/quarter/month/week/day columns, and optionally creates relationships to date columns. |
| `add_measure_table(report, workspace=None, scan_only=False)` | Adds an empty calculated 'Measure' table for centralizing measures in one place. |
| `add_last_refresh_table(report, workspace=None, scan_only=False)` | Adds a 'Last Refresh' table with an M partition that captures the last refresh timestamp. |
| `add_calc_group_units(report, workspace=None, scan_only=False)` | Adds a 'Units' calculation group with Absolute/Thousand/Million items for dynamic number formatting. |
| `add_calc_group_time_intelligence(report, workspace=None, scan_only=False)` | Adds a 'Time Intelligence' calculation group with YTD, QTD, MTD, PY, PY YTD, and other time comparison items. |

### Files

- `src/sempy_labs/semantic_model/_Add_CalculatedTable_Calendar.py` (new file)
- `src/sempy_labs/semantic_model/_Add_CalculatedTable_MeasureTable.py` (new file)
- `src/sempy_labs/semantic_model/_Add_Table_LastRefresh.py` (new file)
- `src/sempy_labs/semantic_model/_Add_CalcGroup_Units.py` (new file)
- `src/sempy_labs/semantic_model/_Add_CalcGroup_TimeIntelligence.py` (new file)
- `src/sempy_labs/semantic_model/__init__.py` (updated exports)

### Usage

```python
import sempy_labs as labs

# Check if a calendar table already exists
labs.semantic_model.add_calculated_calendar("My Report", scan_only=True)

# Add a calendar table and auto-create relationships
labs.semantic_model.add_calculated_calendar("My Report")

# Add a Units calculation group
labs.semantic_model.add_calc_group_units("My Report")
```

### Notes

- All functions use XMLA via `connect_semantic_model` (TOM/.NET interop).
- Functions first check whether the component already exists before adding.

---

## PBI Fixer Contribution — Overview

This PR is part of the **PBI Fixer** contribution to semantic-link-labs — an interactive ipywidgets-based UI for scanning and fixing Power BI reports and semantic models directly in Microsoft Fabric Notebooks.

The PBI Fixer provides a tabbed ipywidgets interface (Semantic Model Explorer, Report Explorer, Perspective Editor, Vertipaq Analyzer) that lets users interactively scan, inspect, and fix Power BI artifacts without leaving the notebook. All underlying fixer functions also work as standalone API calls, so users can integrate them into scripts and pipelines without the UI.

### Contribution Structure

The full contribution (~17K lines across 68 files) is split into **22 focused PRs across 6 phases** to keep each PR reviewable and self-contained. Only new files are added in Phases 1–4 and 6 — no existing SLL code is modified.

| Phase | Focus | PRs | Description |
|-------|-------|-----|-------------|
| **1** | **Report Fixers** | 7 | Standalone functions that programmatically fix common Power BI report issues: replace pie charts with bar charts, standardize page sizes to Full HD, apply chart formatting best practices, migrate slicers to slicerbars, hide visual-level filters, clean up unused custom visuals, align visuals, migrate report-level measures, and upgrade reports to PBIR format. Each function operates on PBIR-format report definitions. |
| **2** | **Semantic Model Fixers** | 4 | Functions that fix and enhance semantic models via XMLA/TOM: add calculated calendar and measure tables, add calculation groups for units and time intelligence, discourage implicit measures, and 19 BPA auto-fixers covering formatting conventions, naming standards, data types, column visibility, sort order, and DAX patterns (e.g., use DIVIDE instead of `/`). |
| **3** | **SM Setup & Analysis** | 3 | Setup utilities: configure cache warming queries, set up incremental refresh policies, and prepare semantic models for AI/Copilot integration (descriptions, metadata enrichment). |
| **4** | **Report Utilities** | 3 | Report-level utilities: auto-generate report page prototypes from a semantic model's structure, extract and apply report themes, and generate IBCS-compliant variance charts. |
| **5** | **Upstream Enhancements** | 3 | **⚠️ These PRs modify existing SLL code** (unlike Phases 1–4 which only add new files). Changes include TOM model `.Find()` fixes and expression capture (`tom/_model.py`), Vertipaq analyzer enhancements with memory/column-level analysis (`_vertipaq.py`, ~1000 lines changed), and various small fixes across `_items.py`, `_item_recovery.py`, `_helper_functions.py`, `_export_report.py`, `_sql.py`, and `admin/_tenant.py`. These carry higher merge conflict risk and may need closer review or discussion. |
| **6** | **PBI Fixer UI** | 2 | The interactive UI layer: shared UI components (theme, icons, tree builders, layout helpers), BPA scan runners, report helpers, and the main PBI Fixer application with its tabbed interface (SM Explorer, Report Explorer, Perspective Editor, Vertipaq Analyzer). Depends on Phases 1–5 but uses lazy imports to degrade gracefully if individual fixers aren't yet merged. |

### Dependencies & Review Order

- **Phases 1–4** are fully independent — they only add new files and can be reviewed/merged in any order.
- **Phase 5** is also independent but modifies existing code, so it may benefit from early discussion.
- **Phase 6** (the UI) ties everything together. It depends on the earlier phases but works standalone via lazy imports.
- All fixer functions work without the UI — they can be called directly as `sempy_labs.report.fix_piecharts(...)` or `sempy_labs.semantic_model.add_calculated_calendar(...)`.
