### PR TITLE
Add auto-measure generators: MeasuresFromColumns and PY measures

### DIFF
--- a/src/sempy_labs/semantic_model/_Add_MeasuresFromColumns.py
+++ b/src/sempy_labs/semantic_model/_Add_MeasuresFromColumns.py
@@ -1,0 +1,112 @@
+# Auto-create measures from columns based on SummarizeBy property.
+# For each column where SummarizeBy != "None", creates a measure using
+# the appropriate aggregation function and hides the source column.
+# Ported from Tabular Editor macro: "Selected Measures based on Summarize By Property"
+
+from typing import Optional
+from uuid import UUID
+from sempy._utils._log import log
+import sempy_labs._icons as icons
+
+
+@log
+def add_measures_from_columns(
+    dataset: str | UUID,
+    workspace: Optional[str | UUID] = None,
+    target_table: Optional[str] = None,
+    scan_only: bool = False,
+):
+    """
+    Creates measures from columns based on their SummarizeBy property.
+
+    For each column where SummarizeBy is not "None", a measure is created
+    using the appropriate aggregation (SUM, COUNT, MIN, MAX, etc.).
+    The source column is hidden after measure creation.
+
+    Parameters
+    ----------
+    dataset : str | uuid.UUID
+        Name or ID of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    target_table : str, default=None
+        Table to place new measures in. If None, measures are added to
+        the same table as the source column.
+    scan_only : bool, default=False
+        If True, only reports what would be created without making changes.
+
+    Returns
+    -------
+    int
+        Number of measures created (or that would be created in scan mode).
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    created = 0
+
+    with connect_semantic_model(
+        dataset=dataset, readonly=scan_only, workspace=workspace
+    ) as tom:
+        # Resolve target table if specified
+        measures_table = None
+        if target_table:
+            measures_table = tom.model.Tables.Find(target_table)
+            if measures_table is None:
+                print(f"{icons.red_dot} Target table '{target_table}' not found.")
+                return 0
+        else:
+            # Auto-detect measure table by name
+            for t in tom.model.Tables:
+                if "measure" in t.Name.lower():
+                    measures_table = t
+                    print(f"{icons.info} Auto-detected measure table: '{t.Name}'")
+                    break
+
+        for table in tom.model.Tables:
+            for col in table.Columns:
+                summarize_by = str(col.SummarizeBy) if hasattr(col, "SummarizeBy") else "None"
+                if summarize_by == "None" or summarize_by == "Default":
+                    continue
+
+                agg_fn = summarize_by.upper()
+                measure_name = col.Name
+                dax_expr = f"{agg_fn}('{table.Name}'[{col.Name}])"
+                dest_table = measures_table or table
+
+                # Check if measure already exists
+                existing = dest_table.Measures.Find(measure_name)
+                if existing is not None:
+                    continue
+
+                if scan_only:
+                    print(
+                        f"{icons.yellow_dot} Would create: [{measure_name}] = {dax_expr} "
+                        f"in '{dest_table.Name}'"
+                    )
+                    created += 1
+                    continue
+
+                tom.add_measure(
+                    table_name=dest_table.Name,
+                    measure_name=measure_name,
+                    expression=dax_expr,
+                    format_string="0.0",
+                    description=(
+                        f"Auto-created {agg_fn} measure from column "
+                        f"'{table.Name}'[{col.Name}]"
+                    ),
+                    display_folder=table.Name,
+                )
+                col.IsHidden = True
+                created += 1
+                print(
+                    f"{icons.green_dot} Created [{measure_name}] = {dax_expr} "
+                    f"in '{dest_table.Name}'"
+                )
+
+        if not scan_only and created > 0:
+            tom.model.SaveChanges()
+
+    action = "Would create" if scan_only else "Created"
+    print(f"{icons.info} {action} {created} measure(s) from columns.")
+    return created

--- a/src/sempy_labs/semantic_model/_Add_PYMeasures.py
+++ b/src/sempy_labs/semantic_model/_Add_PYMeasures.py
@@ -1,0 +1,166 @@
+# Add Prior Year (PY) time intelligence measures for selected measures.
+# For each source measure, creates: PY, Δ PY, Δ PY %, Max Green PY, Max Red AC.
+# Ported from Tabular Editor macro: "ALL Y-1"
+
+from typing import Optional, List
+from uuid import UUID
+from sempy._utils._log import log
+import sempy_labs._icons as icons
+
+
+@log
+def add_py_measures(
+    dataset: str | UUID,
+    workspace: Optional[str | UUID] = None,
+    measures: Optional[List[str]] = None,
+    calendar_table: Optional[str] = None,
+    date_column: Optional[str] = None,
+    target_table: Optional[str] = None,
+    scan_only: bool = False,
+):
+    """
+    Creates Prior Year (PY) time intelligence measures for each specified measure.
+
+    For each source measure, generates 5 new measures:
+    - ``{name} PY`` — SAMEPERIODLASTYEAR
+    - ``{name} Δ PY`` — absolute variance
+    - ``{name} Δ PY %`` — relative variance
+    - ``{name} Max Green PY`` — positive variance highlight
+    - ``{name} Max Red AC`` — negative variance highlight
+
+    Parameters
+    ----------
+    dataset : str | uuid.UUID
+        Name or ID of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    measures : list[str], default=None
+        List of measure names to generate PY variants for.
+        If None, generates for ALL measures in the model.
+    calendar_table : str, default=None
+        Name of the calendar/date table. If None, auto-detects
+        by looking for a table with DataCategory="Time" or IsKey column.
+    date_column : str, default=None
+        Name of the date column. If None, auto-detects the key column.
+    target_table : str, default=None
+        Table to place new measures in. If None, measures are added
+        to a "PY" display folder in the same table as the source measure.
+    scan_only : bool, default=False
+        If True, only reports what would be created without making changes.
+
+    Returns
+    -------
+    int
+        Number of measures created (or that would be created in scan mode).
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    created = 0
+
+    with connect_semantic_model(
+        dataset=dataset, readonly=scan_only, workspace=workspace
+    ) as tom:
+        # Auto-detect calendar table
+        cal_table = None
+        if calendar_table:
+            cal_table = tom.model.Tables.Find(calendar_table)
+        else:
+            for t in tom.model.Tables:
+                if str(getattr(t, "DataCategory", "")) == "Time":
+                    cal_table = t
+                    break
+
+        if cal_table is None:
+            print(f"{icons.red_dot} No calendar table found. Specify calendar_table parameter.")
+            return 0
+
+        # Auto-detect date column
+        dt_col = None
+        if date_column:
+            dt_col = date_column
+        else:
+            for c in cal_table.Columns:
+                if getattr(c, "IsKey", False):
+                    dt_col = c.Name
+                    break
+            if dt_col is None:
+                for c in cal_table.Columns:
+                    if "date" in c.Name.lower():
+                        dt_col = c.Name
+                        break
+            if dt_col is None:
+                print(f"{icons.red_dot} No date column found in '{cal_table.Name}'. Specify date_column parameter.")
+                return 0
+
+        cal_name = cal_table.Name
+        print(f"{icons.info} Calendar: '{cal_name}'[{dt_col}]")
+
+        # Resolve target table
+        dest_table_obj = None
+        if target_table:
+            dest_table_obj = tom.model.Tables.Find(target_table)
+            if dest_table_obj is None:
+                print(f"{icons.red_dot} Target table '{target_table}' not found.")
+                return 0
+        else:
+            # Auto-detect measure table by name
+            for t in tom.model.Tables:
+                if "measure" in t.Name.lower():
+                    dest_table_obj = t
+                    print(f"{icons.info} Auto-detected measure table: '{t.Name}'")
+                    break
+
+        # Collect source measures
+        source_measures = []
+        for table in tom.model.Tables:
+            for m in table.Measures:
+                if measures is None or m.Name in measures:
+                    source_measures.append(m)
+
+        if not source_measures:
+            print(f"{icons.yellow_dot} No measures found to process.")
+            return 0
+
+        for m in source_measures:
+            name = m.Name
+            fmt = str(m.FormatString) if m.FormatString else ""
+            folder = str(m.DisplayFolder) if m.DisplayFolder else ""
+            py_folder = f"{folder}\\PY" if folder else "PY"
+            dest = dest_table_obj or m.Table
+
+            variants = [
+                (f"{name} PY", f"CALCULATE([{name}], SAMEPERIODLASTYEAR('{cal_name}'[{dt_col}]))"),
+                (f"{name} \u0394 PY", f"[{name}] - [{name} PY]"),
+                (f"{name} \u0394 PY %", f"DIVIDE([{name}] - [{name} PY], [{name}])"),
+                (f"{name} Max Green PY", f"IF([{name} \u0394 PY] > 0, MAX([{name}], [{name} PY]))"),
+                (f"{name} Max Red AC", f"IF([{name} \u0394 PY] < 0, MAX([{name}], [{name} PY]))"),
+            ]
+
+            for v_name, v_expr in variants:
+                existing = dest.Measures.Find(v_name)
+                if existing is not None:
+                    continue
+
+                if scan_only:
+                    print(f"{icons.yellow_dot} Would create: [{v_name}]")
+                    created += 1
+                    continue
+
+                tom.add_measure(
+                    table_name=dest.Name,
+                    measure_name=v_name,
+                    expression=v_expr,
+                    format_string=fmt,
+                    display_folder=py_folder,
+                )
+                created += 1
+
+            if not scan_only:
+                print(f"{icons.green_dot} Created PY variants for [{name}]")
+
+        if not scan_only and created > 0:
+            tom.model.SaveChanges()
+
+    action = "Would create" if scan_only else "Created"
+    print(f"{icons.info} {action} {created} PY measure(s) from {len(source_measures)} source measure(s).")
+    return created


### PR DESCRIPTION
## Add Auto-Generated Measures

Two functions that auto-generate measures from a semantic model's structure: one creates SUM/COUNT/etc. measures from columns based on their `SummarizeBy` property, and the other creates Prior Year (PY) time intelligence measures for existing measures.

### Functions Added

| Function | Description |
|----------|-------------|
| `add_measures_from_columns(dataset, workspace=None, target_table=None, scan_only=False)` | Creates measures from columns based on their SummarizeBy property (e.g., a column with SummarizeBy=Sum gets a `SUM([Column])` measure). |
| `add_py_measures(dataset, workspace=None, measures=None, calendar_table=None, date_column=None, target_table=None, scan_only=False)` | Creates Prior Year (PY) time intelligence measures for each specified measure using CALCULATE + SAMEPERIODLASTYEAR. |

### Files

- `src/sempy_labs/semantic_model/_Add_MeasuresFromColumns.py` (new file)
- `src/sempy_labs/semantic_model/_Add_PYMeasures.py` (new file)
- `src/sempy_labs/semantic_model/__init__.py` (updated exports)

### Usage

```python
import sempy_labs as labs

# Preview which measures would be created from columns
labs.semantic_model.add_measures_from_columns("My Dataset", scan_only=True)

# Create measures and place them in a specific table
labs.semantic_model.add_measures_from_columns("My Dataset", target_table="Measures")

# Add PY measures for specific measures
labs.semantic_model.add_py_measures("My Dataset", measures=["Total Sales", "Total Cost"])
```

---

## PBI Fixer Contribution — Overview

This PR is part of the **PBI Fixer** contribution to semantic-link-labs — an interactive ipywidgets-based UI for scanning and fixing Power BI reports and semantic models directly in Microsoft Fabric Notebooks.

The PBI Fixer provides a tabbed ipywidgets interface (Semantic Model Explorer, Report Explorer, Perspective Editor, Vertipaq Analyzer) that lets users interactively scan, inspect, and fix Power BI artifacts without leaving the notebook. All underlying fixer functions also work as standalone API calls, so users can integrate them into scripts and pipelines without the UI.

### Contribution Structure

The full contribution (~17K lines across 68 files) is split into **22 focused PRs across 6 phases** to keep each PR reviewable and self-contained. Only new files are added in Phases 1–4 and 6 — no existing SLL code is modified.

| Phase | Focus | PRs | Description |
|-------|-------|-----|-------------|
| **1** | **Report Fixers** | 7 | Standalone functions that programmatically fix common Power BI report issues: replace pie charts with bar charts, standardize page sizes to Full HD, apply chart formatting best practices, migrate slicers to slicerbars, hide visual-level filters, clean up unused custom visuals, align visuals, migrate report-level measures, and upgrade reports to PBIR format. Each function operates on PBIR-format report definitions. |
| **2** | **Semantic Model Fixers** | 4 | Functions that fix and enhance semantic models via XMLA/TOM: add calculated calendar and measure tables, add calculation groups for units and time intelligence, discourage implicit measures, and 19 BPA auto-fixers covering formatting conventions, naming standards, data types, column visibility, sort order, and DAX patterns (e.g., use DIVIDE instead of `/`). |
| **3** | **SM Setup & Analysis** | 3 | Setup utilities: configure cache warming queries, set up incremental refresh policies, and prepare semantic models for AI/Copilot integration (descriptions, metadata enrichment). |
| **4** | **Report Utilities** | 3 | Report-level utilities: auto-generate report page prototypes from a semantic model's structure, extract and apply report themes, and generate IBCS-compliant variance charts. |
| **5** | **Upstream Enhancements** | 3 | **⚠️ These PRs modify existing SLL code** (unlike Phases 1–4 which only add new files). Changes include TOM model `.Find()` fixes and expression capture (`tom/_model.py`), Vertipaq analyzer enhancements with memory/column-level analysis (`_vertipaq.py`, ~1000 lines changed), and various small fixes across `_items.py`, `_item_recovery.py`, `_helper_functions.py`, `_export_report.py`, `_sql.py`, and `admin/_tenant.py`. These carry higher merge conflict risk and may need closer review or discussion. |
| **6** | **PBI Fixer UI** | 2 | The interactive UI layer: shared UI components (theme, icons, tree builders, layout helpers), BPA scan runners, report helpers, and the main PBI Fixer application with its tabbed interface (SM Explorer, Report Explorer, Perspective Editor, Vertipaq Analyzer). Depends on Phases 1–5 but uses lazy imports to degrade gracefully if individual fixers aren't yet merged. |

### Dependencies & Review Order

- **Phases 1–4** are fully independent — they only add new files and can be reviewed/merged in any order.
- **Phase 5** is also independent but modifies existing code, so it may benefit from early discussion.
- **Phase 6** (the UI) ties everything together. It depends on the earlier phases but works standalone via lazy imports.
- All fixer functions work without the UI — they can be called directly as `sempy_labs.report.fix_piecharts(...)` or `sempy_labs.semantic_model.add_calculated_calendar(...)`.
