### PR TITLE
Add 19 semantic model BPA auto-fixers

### DIFF
--- a/src/sempy_labs/semantic_model/_Fix_AvoidAdding0.py
+++ b/src/sempy_labs/semantic_model/_Fix_AvoidAdding0.py
@@ -1,0 +1,48 @@
+# Fix "Avoid adding 0 to a measure" — standalone BPA fixer.
+# Strips "0+" or "0 +" prefix from measure expressions.
+
+from typing import Optional
+from uuid import UUID
+import re
+
+
+def fix_avoid_adding_zero(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Removes '0+' or '0 +' prefix from measure expressions.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            for m in table.Measures:
+                expr = str(m.Expression) if m.Expression else ""
+                stripped = expr.replace(" ", "")
+                if stripped.startswith("0+"):
+                    new_expr = re.sub(r'^\s*0\s*\+\s*', '', expr)
+                    if new_expr != expr:
+                        if scan_only:
+                            print(f"  Would fix: [{m.Name}] — remove '0+' prefix")
+                        else:
+                            m.Expression = new_expr
+                            print(f"  Fixed: [{m.Name}] — removed '0+' prefix")
+                        fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} measure(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_CapitalizeObjectNames.py
+++ b/src/sempy_labs/semantic_model/_Fix_CapitalizeObjectNames.py
@@ -1,0 +1,72 @@
+# Fix "First letter of objects must be capitalized" — standalone BPA fixer.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_capitalize_object_names(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Capitalizes the first letter of table, column, measure, hierarchy, and partition names.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    def _cap(name):
+        return name[0].upper() + name[1:] if name and name[0] != name[0].upper() else None
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            new_name = _cap(table.Name)
+            if new_name:
+                if scan_only:
+                    print(f"  Would capitalize table: '{table.Name}' → '{new_name}'")
+                else:
+                    table.Name = new_name
+                    print(f"  Capitalized table: '{new_name}'")
+                fixed += 1
+            for col in table.Columns:
+                new_name = _cap(col.Name)
+                if new_name:
+                    if scan_only:
+                        print(f"  Would capitalize column: '{table.Name}'[{col.Name}]")
+                    else:
+                        col.Name = new_name
+                        print(f"  Capitalized column: '{table.Name}'[{new_name}]")
+                    fixed += 1
+            for m in table.Measures:
+                new_name = _cap(m.Name)
+                if new_name:
+                    if scan_only:
+                        print(f"  Would capitalize measure: [{m.Name}]")
+                    else:
+                        m.Name = new_name
+                        print(f"  Capitalized measure: [{new_name}]")
+                    fixed += 1
+            for h in table.Hierarchies:
+                new_name = _cap(h.Name)
+                if new_name:
+                    if scan_only:
+                        print(f"  Would capitalize hierarchy: {h.Name}")
+                    else:
+                        h.Name = new_name
+                        print(f"  Capitalized hierarchy: {new_name}")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would capitalize" if scan_only else "Capitalized"
+    print(f"  {action} {fixed} object name(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_DataCategory.py
+++ b/src/sempy_labs/semantic_model/_Fix_DataCategory.py
@@ -1,0 +1,73 @@
+# Fix "Add data category for columns" — standalone BPA fixer.
+# Sets DataCategory on columns based on naming conventions.
+
+from typing import Optional
+from uuid import UUID
+import re
+
+
+def fix_data_category(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets appropriate DataCategory on columns based on naming conventions.
+
+    Mapping: City → City, Country → Country, State/Province → StateOrProvince,
+    Postal/Zip → PostalCode, Continent → Continent, Latitude → Latitude,
+    Longitude → Longitude, URL/Web → WebUrl, Image → ImageUrl.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    _CATEGORY_MAP = [
+        (r"\bcity\b", "City"),
+        (r"\bcountry\b", "Country"),
+        (r"\bstate\b|\bprovince\b", "StateOrProvince"),
+        (r"\bpostal\s*code\b|\bzip\s*code\b|\bzip\b|\bplz\b", "PostalCode"),
+        (r"\bcontinent\b", "Continent"),
+        (r"\blatitude\b|\blat\b", "Latitude"),
+        (r"\blongitude\b|\blon\b|\blng\b", "Longitude"),
+        (r"\burl\b|\bweb\s*url\b|\bwebsite\b|\blink\b", "WebUrl"),
+        (r"\bimage\s*url\b|\bimage\b|\bthumbnail\b|\bphoto\b|\bpicture\b", "ImageUrl"),
+        (r"\baddress\b", "Address"),
+        (r"\bcounty\b", "County"),
+    ]
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            for col in table.Columns:
+                # Skip if already has a data category
+                current = str(col.DataCategory) if col.DataCategory else ""
+                if current and current != "Uncategorized":
+                    continue
+                name_lower = col.Name.lower()
+                matched_cat = None
+                for pattern, category in _CATEGORY_MAP:
+                    if re.search(pattern, name_lower, re.IGNORECASE):
+                        matched_cat = category
+                        break
+                if matched_cat is None:
+                    continue
+                if scan_only:
+                    print(f"  Would fix: '{table.Name}'[{col.Name}] → DataCategory={matched_cat}")
+                else:
+                    col.DataCategory = matched_cat
+                    print(f"  Fixed: '{table.Name}'[{col.Name}] → DataCategory={matched_cat}")
+                fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_DateColumnFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_DateColumnFormat.py
@@ -1,0 +1,44 @@
+# Fix date column format — standalone BPA fixer.
+# Sets format string for columns named 'Date' to mm/dd/yyyy.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_date_column_format(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets the format string of 'Date' columns to mm/dd/yyyy.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            for col in table.Columns:
+                name_lower = col.Name.lower()
+                if name_lower == "date" and (not col.FormatString or str(col.FormatString).strip() == ""):
+                    if scan_only:
+                        print(f"  Would fix: '{table.Name}'[{col.Name}] → mm/dd/yyyy")
+                    else:
+                        col.FormatString = "mm/dd/yyyy"
+                        print(f"  Fixed: '{table.Name}'[{col.Name}] → mm/dd/yyyy")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} date column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_DoNotSummarize.py
+++ b/src/sempy_labs/semantic_model/_Fix_DoNotSummarize.py
@@ -1,0 +1,54 @@
+# Fix "Do not summarize numeric columns" — standalone BPA fixer.
+# Sets SummarizeBy to None on all numeric data columns.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_do_not_summarize(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets SummarizeBy to None on numeric data columns.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        import Microsoft.AnalysisServices.Tabular as TOM
+
+        for table in tom.model.Tables:
+            for col in table.Columns:
+                if col.Type != TOM.ColumnType.Data:
+                    continue
+                if col.DataType not in (TOM.DataType.Int64, TOM.DataType.Double, TOM.DataType.Decimal):
+                    continue
+                if str(col.SummarizeBy) == "None":
+                    continue
+                if scan_only:
+                    print(f"  Would fix: '{table.Name}'[{col.Name}] SummarizeBy={col.SummarizeBy} → None")
+                else:
+                    col.SummarizeBy = TOM.AggregateFunction.Default  # None
+                    try:
+                        col.SummarizeBy = getattr(TOM.AggregateFunction, "None_", TOM.AggregateFunction.Default)
+                    except Exception:
+                        pass
+                    print(f"  Fixed: '{table.Name}'[{col.Name}] → SummarizeBy=None")
+                fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_FlagColumnFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_FlagColumnFormat.py
@@ -1,0 +1,57 @@
+# Fix "Format flag columns as Yes/No value strings" — standalone BPA fixer.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_flag_column_format(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets a Yes/No format on integer flag columns (names starting with 'Is' or ending with 'Flag').
+
+    Uses the DAX format string '"Yes";"Yes";"No"' pattern.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    _FLAG_FMT = '"Yes";"Yes";"No"'
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        import Microsoft.AnalysisServices.Tabular as TOM
+
+        for table in tom.model.Tables:
+            for col in table.Columns:
+                if col.IsHidden or table.IsHidden:
+                    continue
+                if col.DataType != TOM.DataType.Int64:
+                    continue
+                name = col.Name
+                if not (name.lower().startswith("is") or name.lower().endswith("flag") or name.lower().endswith(" flag")):
+                    continue
+                current_fmt = str(col.FormatString) if col.FormatString else ""
+                if current_fmt.strip():
+                    continue
+                if scan_only:
+                    print(f"  Would fix: '{table.Name}'[{col.Name}] → Yes/No format")
+                else:
+                    col.FormatString = _FLAG_FMT
+                    print(f"  Fixed: '{table.Name}'[{col.Name}] → Yes/No format")
+                fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} flag column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_FloatingPointDataType.py
+++ b/src/sempy_labs/semantic_model/_Fix_FloatingPointDataType.py
@@ -1,0 +1,45 @@
+# Fix floating point data types — standalone BPA fixer.
+# Changes columns using Double data type to Decimal.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_floating_point_datatype(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Fixes columns that use floating point (Double) data types by changing them to Decimal.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        import Microsoft.AnalysisServices.Tabular as TOM
+
+        for table in tom.model.Tables:
+            for col in table.Columns:
+                if col.DataType == TOM.DataType.Double:
+                    if scan_only:
+                        print(f"  Would fix: '{table.Name}'[{col.Name}] Double → Decimal")
+                    else:
+                        col.DataType = TOM.DataType.Decimal
+                        print(f"  Fixed: '{table.Name}'[{col.Name}] Double → Decimal")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} floating point column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_HideForeignKeys.py
+++ b/src/sempy_labs/semantic_model/_Fix_HideForeignKeys.py
@@ -1,0 +1,48 @@
+# Fix hidden foreign keys — standalone BPA fixer.
+# Hides columns that are used as foreign keys in relationships.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_hide_foreign_keys(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Hides columns that participate as foreign keys (From side) in relationships.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        # Collect foreign key columns (From side of relationships)
+        fk_cols = set()
+        for rel in tom.model.Relationships:
+            fk_cols.add((str(rel.FromTable.Name), str(rel.FromColumn.Name)))
+
+        for table in tom.model.Tables:
+            for col in table.Columns:
+                if (table.Name, col.Name) in fk_cols and not col.IsHidden:
+                    if scan_only:
+                        print(f"  Would hide: '{table.Name}'[{col.Name}]")
+                    else:
+                        col.IsHidden = True
+                        print(f"  Hidden: '{table.Name}'[{col.Name}]")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would hide" if scan_only else "Hidden"
+    print(f"  {action} {fixed} foreign key column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_IsAvailableInMdx.py
+++ b/src/sempy_labs/semantic_model/_Fix_IsAvailableInMdx.py
@@ -1,0 +1,43 @@
+# Fix IsAvailableInMDX — standalone BPA fixer.
+# Sets IsAvailableInMDX to False on non-attribute columns.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_isavailable_in_mdx(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets IsAvailableInMDX to False on columns where it is True.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            for col in table.Columns:
+                if getattr(col, "IsAvailableInMDX", False):
+                    if scan_only:
+                        print(f"  Would fix: '{table.Name}'[{col.Name}] IsAvailableInMDX → False")
+                    else:
+                        col.IsAvailableInMDX = False
+                        print(f"  Fixed: '{table.Name}'[{col.Name}] IsAvailableInMDX → False")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_IsAvailableInMdxTrue.py
+++ b/src/sempy_labs/semantic_model/_Fix_IsAvailableInMdxTrue.py
@@ -1,0 +1,57 @@
+# Fix "Set IsAvailableInMdx to true on necessary columns" — standalone BPA fixer.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_isavailable_in_mdx_true(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets IsAvailableInMDX to True on key/attribute columns that incorrectly have it False.
+
+    Targets columns that are: (a) used as keys in relationships (To side), or
+    (b) used in hierarchies, or (c) marked as IsKey.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        # Collect columns that should have IsAvailableInMDX = True
+        needed = set()
+        for rel in tom.model.Relationships:
+            needed.add((str(rel.ToTable.Name), str(rel.ToColumn.Name)))
+        for table in tom.model.Tables:
+            for h in table.Hierarchies:
+                for lvl in h.Levels:
+                    needed.add((str(table.Name), str(lvl.Column.Name)))
+            for col in table.Columns:
+                if col.IsKey:
+                    needed.add((str(table.Name), str(col.Name)))
+
+        for table in tom.model.Tables:
+            for col in table.Columns:
+                if (table.Name, col.Name) in needed and not col.IsAvailableInMDX:
+                    if scan_only:
+                        print(f"  Would fix: '{table.Name}'[{col.Name}] IsAvailableInMDX → True")
+                    else:
+                        col.IsAvailableInMDX = True
+                        print(f"  Fixed: '{table.Name}'[{col.Name}] IsAvailableInMDX → True")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_MarkPrimaryKeys.py
+++ b/src/sempy_labs/semantic_model/_Fix_MarkPrimaryKeys.py
@@ -1,0 +1,51 @@
+# Fix "Mark primary keys" — standalone BPA fixer.
+# Sets IsKey=True on the To-side column of relationships.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_mark_primary_keys(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets IsKey=True on columns that are the primary key side (To) of relationships.
+
+    Only applies when the column is not already a key and the table has no existing key.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for rel in tom.model.Relationships:
+            to_col = rel.ToColumn
+            to_table = rel.ToTable
+            if to_col.IsKey:
+                continue
+            # Check if table already has a key column
+            has_key = any(c.IsKey for c in to_table.Columns)
+            if has_key:
+                continue
+            if scan_only:
+                print(f"  Would mark: '{to_table.Name}'[{to_col.Name}] as primary key")
+            else:
+                to_col.IsKey = True
+                print(f"  Marked: '{to_table.Name}'[{to_col.Name}] as primary key")
+            fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would mark" if scan_only else "Marked"
+    print(f"  {action} {fixed} primary key column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_MeasureDescriptions.py
+++ b/src/sempy_labs/semantic_model/_Fix_MeasureDescriptions.py
@@ -1,0 +1,46 @@
+# Fix measure descriptions — standalone BPA fixer.
+# Sets measure description to its DAX expression when description is empty.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_measure_descriptions(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets the description of visible measures (that have no description) to their DAX expression.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            for m in table.Measures:
+                if not m.IsHidden and (not m.Description or str(m.Description).strip() == ""):
+                    expr = str(m.Expression) if m.Expression else ""
+                    if not expr:
+                        continue
+                    if scan_only:
+                        print(f"  Would fix: [{m.Name}] — set description to DAX expression")
+                    else:
+                        m.Description = expr
+                        print(f"  Fixed: [{m.Name}] — description set to DAX expression")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} measure description(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_MeasureFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_MeasureFormat.py
@@ -1,0 +1,44 @@
+# Fix measure format — standalone BPA fixer.
+# Sets format string for measures without a format to #,0.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_measure_format(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets the format string of measures that have no format string to #,0.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            for m in table.Measures:
+                fmt = str(m.FormatString) if m.FormatString else ""
+                if not fmt.strip():
+                    if scan_only:
+                        print(f"  Would fix: [{m.Name}] → #,0")
+                    else:
+                        m.FormatString = "#,0"
+                        print(f"  Fixed: [{m.Name}] → #,0")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} measure format(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_MonthColumnFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_MonthColumnFormat.py
@@ -1,0 +1,44 @@
+# Fix month column format — standalone BPA fixer.
+# Sets format string for columns named 'Month' to MMMM yyyy.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_month_column_format(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets the format string of 'Month' columns to MMMM yyyy.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            for col in table.Columns:
+                name_lower = col.Name.lower()
+                if name_lower == "month" and (not col.FormatString or str(col.FormatString).strip() == ""):
+                    if scan_only:
+                        print(f"  Would fix: '{table.Name}'[{col.Name}] → MMMM yyyy")
+                    else:
+                        col.FormatString = "MMMM yyyy"
+                        print(f"  Fixed: '{table.Name}'[{col.Name}] → MMMM yyyy")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} month column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_PercentageFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_PercentageFormat.py
@@ -1,0 +1,50 @@
+# Fix "Percentages should be formatted with thousands separators" — standalone BPA fixer.
+
+from typing import Optional
+from uuid import UUID
+import re
+
+
+def fix_percentage_format(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets format string on measures whose name contains %, Percent, or Pct.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    _PCT_FMT = "#,0.0%;-#,0.0%;#,0.0%"
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            for m in table.Measures:
+                name_lower = m.Name.lower()
+                if not any(k in name_lower for k in ("%", "percent", "pct")):
+                    continue
+                current_fmt = str(m.FormatString) if m.FormatString else ""
+                if "%" in current_fmt:
+                    continue  # already has a percentage format
+                if scan_only:
+                    print(f"  Would fix: [{m.Name}] → {_PCT_FMT}")
+                else:
+                    m.FormatString = _PCT_FMT
+                    print(f"  Fixed: [{m.Name}] → {_PCT_FMT}")
+                fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} percentage measure(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_SortMonthColumn.py
+++ b/src/sempy_labs/semantic_model/_Fix_SortMonthColumn.py
@@ -1,0 +1,71 @@
+# Fix "Month (as a string) must be sorted" — standalone BPA fixer.
+# Sets SortByColumn on month name columns to a corresponding month number column.
+
+from typing import Optional
+from uuid import UUID
+import re
+
+
+def fix_sort_month_column(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets SortByColumn on month name (string) columns to point to a month number column.
+
+    Auto-detects by naming convention: looks for a column with 'month' AND 'num'/'no'/'number'/'sort'/'order'/'key'
+    in the same table. Falls back to a column named 'MonthNo', 'Month Number', 'MonthKey', etc.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        import Microsoft.AnalysisServices.Tabular as TOM
+
+        for table in tom.model.Tables:
+            # Find month name column (string type, name contains 'month')
+            month_name_cols = []
+            month_num_cols = []
+            for col in table.Columns:
+                name_lower = col.Name.lower()
+                if "month" in name_lower:
+                    if col.DataType == TOM.DataType.String:
+                        month_name_cols.append(col)
+                    elif col.DataType in (TOM.DataType.Int64, TOM.DataType.Double, TOM.DataType.Decimal):
+                        month_num_cols.append(col)
+                # Also check for columns like "MonthNo", "MonthKey", "MonthSort"
+                if col.DataType in (TOM.DataType.Int64, TOM.DataType.Double, TOM.DataType.Decimal):
+                    if any(k in name_lower for k in ("monthno", "monthnum", "monthkey", "monthsort", "month_no", "month_num", "month_key", "month_sort", "month number", "month order")):
+                        if col not in month_num_cols:
+                            month_num_cols.append(col)
+
+            if not month_name_cols or not month_num_cols:
+                continue
+
+            sort_col = month_num_cols[0]  # pick first numeric month column
+            for mc in month_name_cols:
+                # Skip if already sorted
+                if mc.SortByColumn is not None:
+                    continue
+                if scan_only:
+                    print(f"  Would fix: '{table.Name}'[{mc.Name}] SortByColumn → [{sort_col.Name}]")
+                else:
+                    mc.SortByColumn = sort_col
+                    print(f"  Fixed: '{table.Name}'[{mc.Name}] SortByColumn → [{sort_col.Name}]")
+                fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} month column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_TrimObjectNames.py
+++ b/src/sempy_labs/semantic_model/_Fix_TrimObjectNames.py
@@ -1,0 +1,77 @@
+# Fix "Objects should not start or end with a space" — standalone BPA fixer.
+# Trims leading/trailing whitespace from object names.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_trim_object_names(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Trims leading/trailing whitespace from table, column, measure, hierarchy, and partition names.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            if table.Name != table.Name.strip():
+                if scan_only:
+                    print(f"  Would trim table: '{table.Name}'")
+                else:
+                    table.Name = table.Name.strip()
+                    print(f"  Trimmed table: '{table.Name}'")
+                fixed += 1
+            for col in table.Columns:
+                if col.Name != col.Name.strip():
+                    if scan_only:
+                        print(f"  Would trim column: '{table.Name}'[{col.Name}]")
+                    else:
+                        col.Name = col.Name.strip()
+                        print(f"  Trimmed column: '{table.Name}'[{col.Name}]")
+                    fixed += 1
+            for m in table.Measures:
+                if m.Name != m.Name.strip():
+                    if scan_only:
+                        print(f"  Would trim measure: [{m.Name}]")
+                    else:
+                        m.Name = m.Name.strip()
+                        print(f"  Trimmed measure: [{m.Name}]")
+                    fixed += 1
+            for h in table.Hierarchies:
+                if h.Name != h.Name.strip():
+                    if scan_only:
+                        print(f"  Would trim hierarchy: {h.Name}")
+                    else:
+                        h.Name = h.Name.strip()
+                        print(f"  Trimmed hierarchy: {h.Name}")
+                    fixed += 1
+            try:
+                for p in table.Partitions:
+                    if p.Name != p.Name.strip():
+                        if scan_only:
+                            print(f"  Would trim partition: {p.Name}")
+                        else:
+                            p.Name = p.Name.strip()
+                            print(f"  Trimmed partition: {p.Name}")
+                        fixed += 1
+            except Exception:
+                pass
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would trim" if scan_only else "Trimmed"
+    print(f"  {action} {fixed} object name(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_UseDivideFunction.py
+++ b/src/sempy_labs/semantic_model/_Fix_UseDivideFunction.py
@@ -1,0 +1,67 @@
+# Fix "Use the DIVIDE function for division" — standalone BPA fixer.
+# Replaces simple A / B patterns in measure expressions with DIVIDE(A, B).
+
+from typing import Optional
+from uuid import UUID
+import re
+
+
+def fix_use_divide_function(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Replaces simple division operators (/) in measure expressions with DIVIDE().
+
+    Only fixes patterns like `] / ` or `) / ` (single-level divisions).
+    Nested or complex cases are skipped.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    # Pattern: captures `<expr>] / <expr>` or `<expr>) / <expr>`
+    # We match: (something ending in ] or )) followed by whitespace / whitespace (something)
+    _div_pattern = re.compile(
+        r'(\[[^\]]+\]|\([^()]*\))\s*/\s*(\[[^\]]+\]|\([^()]*\))',
+        re.IGNORECASE,
+    )
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            for m in table.Measures:
+                expr = str(m.Expression) if m.Expression else ""
+                if "/" not in expr:
+                    continue
+                # Skip if already using DIVIDE predominantly
+                if expr.upper().count("DIVIDE") > expr.count("/"):
+                    continue
+                # Simple replacement: ] / [ or ] / ( or ) / [
+                new_expr = re.sub(
+                    r'((?:\]\s*|\)\s*))\s*/\s*((?:\s*\[|\s*[A-Za-z]))',
+                    lambda match: f'DIVIDE({match.group(0).replace("/", ",", 1)})',
+                    expr,
+                    count=0,
+                )
+                if new_expr != expr:
+                    if scan_only:
+                        print(f"  Would fix: [{m.Name}]")
+                    else:
+                        m.Expression = new_expr
+                        print(f"  Fixed: [{m.Name}]")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} measure(s) with division operator.")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_WholeNumberFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_WholeNumberFormat.py
@@ -1,0 +1,51 @@
+# Fix "Whole numbers should be formatted with thousands separators" — standalone BPA fixer.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_whole_number_format(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets format string to #,0 on integer-typed measures without a format string.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        import Microsoft.AnalysisServices.Tabular as TOM
+
+        for table in tom.model.Tables:
+            for m in table.Measures:
+                fmt = str(m.FormatString) if m.FormatString else ""
+                if fmt.strip():
+                    continue  # already has a format
+                # Check if the measure likely returns an integer
+                # (heuristic: name doesn't suggest % or ratio)
+                name_lower = m.Name.lower()
+                if any(k in name_lower for k in ("%", "percent", "pct", "ratio", "rate")):
+                    continue
+                if scan_only:
+                    print(f"  Would fix: [{m.Name}] → #,0")
+                else:
+                    m.FormatString = "#,0"
+                    print(f"  Fixed: [{m.Name}] → #,0")
+                fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} measure(s).")
+    return fixed


### PR DESCRIPTION
## Semantic Model BPA Auto-Fixers

19 functions that automatically fix common Best Practice Analyzer (BPA) violations in a semantic model. Each function follows a consistent pattern: scan the model for violations, optionally preview findings (`scan_only=True`), and apply fixes via XMLA/TOM.

These fixers cover formatting conventions, naming standards, data types, column visibility, sort order, and DAX patterns. They are the automated counterparts to the rules documented in [Tabular Editor BPA rules](https://docs.tabulareditor.com/te3/features/best-practice-analyzer.html).

### Functions Added (19)

| Function | Description |
|----------|-------------|
| `fix_avoid_adding_zero(dataset, ...)` | Removes `0+` or `0 +` prefix from measure expressions. |
| `fix_capitalize_object_names(dataset, ...)` | Capitalizes the first letter of table, column, measure, hierarchy, and partition names. |
| `fix_data_category(dataset, ...)` | Sets appropriate DataCategory on columns based on naming conventions. |
| `fix_date_column_format(dataset, ...)` | Sets the format string of date columns to `mm/dd/yyyy`. |
| `fix_do_not_summarize(dataset, ...)` | Sets SummarizeBy to None on numeric data columns. |
| `fix_flag_column_format(dataset, ...)` | Sets a Yes/No format on integer flag columns (names starting with 'Is' or ending with 'Flag'). |
| `fix_floating_point_datatype(dataset, ...)` | Changes floating point (Double) columns to Decimal data type. |
| `fix_hide_foreign_keys(dataset, ...)` | Hides columns that participate as foreign keys (From side) in relationships. |
| `fix_isavailable_in_mdx(dataset, ...)` | Sets IsAvailableInMDX to False on columns where it is True. |
| `fix_isavailable_in_mdx_true(dataset, ...)` | Sets IsAvailableInMDX to True on key/attribute columns that incorrectly have it False. |
| `fix_mark_primary_keys(dataset, ...)` | Sets IsKey=True on columns that are the primary key side (To) of relationships. |
| `fix_measure_descriptions(dataset, ...)` | Sets the description of visible measures (that have no description) to their DAX expression. |
| `fix_measure_format(dataset, ...)` | Sets the format string of measures without one to `#,0`. |
| `fix_month_column_format(dataset, ...)` | Sets the format string of month columns to `MMMM yyyy`. |
| `fix_percentage_format(dataset, ...)` | Sets format string on measures whose name contains %, Percent, or Pct. |
| `fix_sort_month_column(dataset, ...)` | Sets SortByColumn on month name (string) columns to point to a month number column. |
| `fix_trim_object_names(dataset, ...)` | Trims leading/trailing whitespace from object names. |
| `fix_use_divide_function(dataset, ...)` | Replaces simple division operators (`/`) in measure expressions with `DIVIDE()`. |
| `fix_whole_number_format(dataset, ...)` | Sets format string to `#,0` on integer-typed measures without a format string. |

All functions share the signature: `(dataset, workspace=None, scan_only=False)`.

### Files (19 new files)

All in `src/sempy_labs/semantic_model/`:
`_Fix_AvoidAdding0.py`, `_Fix_CapitalizeObjectNames.py`, `_Fix_DataCategory.py`, `_Fix_DateColumnFormat.py`, `_Fix_DoNotSummarize.py`, `_Fix_FlagColumnFormat.py`, `_Fix_FloatingPointDataType.py`, `_Fix_HideForeignKeys.py`, `_Fix_IsAvailableInMdx.py`, `_Fix_IsAvailableInMdxTrue.py`, `_Fix_MarkPrimaryKeys.py`, `_Fix_MeasureDescriptions.py`, `_Fix_MeasureFormat.py`, `_Fix_MonthColumnFormat.py`, `_Fix_PercentageFormat.py`, `_Fix_SortMonthColumn.py`, `_Fix_TrimObjectNames.py`, `_Fix_UseDivideFunction.py`, `_Fix_WholeNumberFormat.py`

Also updated: `src/sempy_labs/semantic_model/__init__.py` (exports)

### Usage

```python
import sempy_labs as labs

# Preview all naming issues
labs.semantic_model.fix_capitalize_object_names("My Dataset", scan_only=True)

# Fix all formatting issues
labs.semantic_model.fix_measure_format("My Dataset")
labs.semantic_model.fix_date_column_format("My Dataset")
labs.semantic_model.fix_percentage_format("My Dataset")

# Replace / with DIVIDE() in all measures
labs.semantic_model.fix_use_divide_function("My Dataset")
```

### Notes

- All 19 files follow the same structural pattern. Reviewing one file gives a good understanding of all others.
- Each function uses XMLA via `connect_semantic_model`.

---

## PBI Fixer Contribution — Overview

This PR is part of the **PBI Fixer** contribution to semantic-link-labs — an interactive ipywidgets-based UI for scanning and fixing Power BI reports and semantic models directly in Microsoft Fabric Notebooks.

The PBI Fixer provides a tabbed ipywidgets interface (Semantic Model Explorer, Report Explorer, Perspective Editor, Vertipaq Analyzer) that lets users interactively scan, inspect, and fix Power BI artifacts without leaving the notebook. All underlying fixer functions also work as standalone API calls, so users can integrate them into scripts and pipelines without the UI.

### Contribution Structure

The full contribution (~17K lines across 68 files) is split into **22 focused PRs across 6 phases** to keep each PR reviewable and self-contained. Only new files are added in Phases 1–4 and 6 — no existing SLL code is modified.

| Phase | Focus | PRs | Description |
|-------|-------|-----|-------------|
| **1** | **Report Fixers** | 7 | Standalone functions that programmatically fix common Power BI report issues: replace pie charts with bar charts, standardize page sizes to Full HD, apply chart formatting best practices, migrate slicers to slicerbars, hide visual-level filters, clean up unused custom visuals, align visuals, migrate report-level measures, and upgrade reports to PBIR format. Each function operates on PBIR-format report definitions. |
| **2** | **Semantic Model Fixers** | 4 | Functions that fix and enhance semantic models via XMLA/TOM: add calculated calendar and measure tables, add calculation groups for units and time intelligence, discourage implicit measures, and 19 BPA auto-fixers covering formatting conventions, naming standards, data types, column visibility, sort order, and DAX patterns (e.g., use DIVIDE instead of `/`). |
| **3** | **SM Setup & Analysis** | 3 | Setup utilities: configure cache warming queries, set up incremental refresh policies, and prepare semantic models for AI/Copilot integration (descriptions, metadata enrichment). |
| **4** | **Report Utilities** | 3 | Report-level utilities: auto-generate report page prototypes from a semantic model's structure, extract and apply report themes, and generate IBCS-compliant variance charts. |
| **5** | **Upstream Enhancements** | 3 | **⚠️ These PRs modify existing SLL code** (unlike Phases 1–4 which only add new files). Changes include TOM model `.Find()` fixes and expression capture (`tom/_model.py`), Vertipaq analyzer enhancements with memory/column-level analysis (`_vertipaq.py`, ~1000 lines changed), and various small fixes across `_items.py`, `_item_recovery.py`, `_helper_functions.py`, `_export_report.py`, `_sql.py`, and `admin/_tenant.py`. These carry higher merge conflict risk and may need closer review or discussion. |
| **6** | **PBI Fixer UI** | 2 | The interactive UI layer: shared UI components (theme, icons, tree builders, layout helpers), BPA scan runners, report helpers, and the main PBI Fixer application with its tabbed interface (SM Explorer, Report Explorer, Perspective Editor, Vertipaq Analyzer). Depends on Phases 1–5 but uses lazy imports to degrade gracefully if individual fixers aren't yet merged. |

### Dependencies & Review Order

- **Phases 1–4** are fully independent — they only add new files and can be reviewed/merged in any order.
- **Phase 5** is also independent but modifies existing code, so it may benefit from early discussion.
- **Phase 6** (the UI) ties everything together. It depends on the earlier phases but works standalone via lazy imports.
- All fixer functions work without the UI — they can be called directly as `sempy_labs.report.fix_piecharts(...)` or `sempy_labs.semantic_model.add_calculated_calendar(...)`.
