### PR TITLE
Add PBI Fixer shared UI components and BPA runners

### DIFF
--- a/src/sempy_labs/_fix_model_bpa.py
+++ b/src/sempy_labs/_fix_model_bpa.py
@@ -1,0 +1,123 @@
+# Fix Model BPA — Standalone function to scan Model BPA and auto-fix all fixable violations.
+# Runs run_model_bpa(), maps violations to standalone SM fixer files, executes them.
+
+from uuid import UUID
+from typing import Optional
+from sempy._utils._log import log
+import sempy_labs._icons as icons
+
+
+# Mapping: BPA rule name (lowercased) → (module_path, function_name)
+_RULE_TO_FIXER = {
+    "do not use floating point data types": ("sempy_labs.semantic_model._Fix_FloatingPointDataType", "fix_floating_point_datatype"),
+    "do not use floating point data type": ("sempy_labs.semantic_model._Fix_FloatingPointDataType", "fix_floating_point_datatype"),
+    "set isavailableinmdx to false on non-attribute columns": ("sempy_labs.semantic_model._Fix_IsAvailableInMdx", "fix_isavailable_in_mdx"),
+    "set isavailableinmdx to true on necessary columns": ("sempy_labs.semantic_model._Fix_IsAvailableInMdxTrue", "fix_isavailable_in_mdx_true"),
+    "provide format string for 'date' columns": ("sempy_labs.semantic_model._Fix_DateColumnFormat", "fix_date_column_format"),
+    "provide format string for 'month' columns": ("sempy_labs.semantic_model._Fix_MonthColumnFormat", "fix_month_column_format"),
+    "provide format string for measures": ("sempy_labs.semantic_model._Fix_MeasureFormat", "fix_measure_format"),
+    "hide foreign keys": ("sempy_labs.semantic_model._Fix_HideForeignKeys", "fix_hide_foreign_keys"),
+    "objects should not start or end with a space": ("sempy_labs.semantic_model._Fix_TrimObjectNames", "fix_trim_object_names"),
+    "first letter of objects must be capitalized": ("sempy_labs.semantic_model._Fix_CapitalizeObjectNames", "fix_capitalize_object_names"),
+    "do not summarize numeric columns": ("sempy_labs.semantic_model._Fix_DoNotSummarize", "fix_do_not_summarize"),
+    "mark primary keys": ("sempy_labs.semantic_model._Fix_MarkPrimaryKeys", "fix_mark_primary_keys"),
+    "percentages should be formatted with thousands separators and 1 decimal": ("sempy_labs.semantic_model._Fix_PercentageFormat", "fix_percentage_format"),
+    "format flag columns as yes/no value strings": ("sempy_labs.semantic_model._Fix_FlagColumnFormat", "fix_flag_column_format"),
+    "visible objects with no description": ("sempy_labs.semantic_model._Fix_MeasureDescriptions", "fix_measure_descriptions"),
+    "avoid adding 0 to a measure": ("sempy_labs.semantic_model._Fix_AvoidAdding0", "fix_avoid_adding_zero"),
+    "use the divide function for division": ("sempy_labs.semantic_model._Fix_UseDivideFunction", "fix_use_divide_function"),
+    "whole numbers should be formatted with thousands separators": ("sempy_labs.semantic_model._Fix_WholeNumberFormat", "fix_whole_number_format"),
+    "month (as a string) must be sorted": ("sempy_labs.semantic_model._Fix_SortMonthColumn", "fix_sort_month_column"),
+    "add data category for columns": ("sempy_labs.semantic_model._Fix_DataCategory", "fix_data_category"),
+}
+
+
+@log
+def fix_model_bpa(
+    dataset: str | UUID,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+) -> None:
+    """
+    Scans Model BPA rules and auto-fixes all fixable violations using
+    standalone fixer scripts. Each fixer runs in bulk (entire model),
+    not per-violation.
+
+    Parameters
+    ----------
+    dataset : str | uuid.UUID
+        Name or ID of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports which fixers would run without applying changes.
+
+    Returns
+    -------
+    None
+    """
+    import importlib
+
+    from sempy_labs import run_model_bpa
+    import IPython.display as _ipd
+    _orig_display = _ipd.display
+    _ipd.display = lambda *a, **kw: None
+    try:
+        df = run_model_bpa(dataset=dataset, workspace=workspace, return_dataframe=True)
+    finally:
+        _ipd.display = _orig_display
+
+    if df is None or len(df) == 0:
+        print(f"{icons.green_dot} No Model BPA violations found for '{dataset}'.")
+        return
+
+    # Determine which fixers are needed
+    violated_rules = set(df["Rule Name"].str.lower().str.strip().unique())
+    fixers_to_run = {}
+    for rule in violated_rules:
+        if rule in _RULE_TO_FIXER:
+            mod_path, fn_name = _RULE_TO_FIXER[rule]
+            fixers_to_run[rule] = (mod_path, fn_name)
+
+    unfixable = violated_rules - set(fixers_to_run.keys())
+
+    if not fixers_to_run:
+        print(f"{icons.info} {len(df)} violation(s) found but none have auto-fixers.")
+        for rule in sorted(violated_rules):
+            count = len(df[df["Rule Name"].str.lower().str.strip() == rule])
+            print(f"  \u2022 {rule} ({count} violation(s)) — no auto-fixer")
+        return
+
+    print(f"{icons.info} {len(df)} violation(s) across {len(violated_rules)} rule(s). "
+          f"{len(fixers_to_run)} fixable, {len(unfixable)} informational.")
+
+    if unfixable:
+        for rule in sorted(unfixable):
+            count = len(df[df["Rule Name"].str.lower().str.strip() == rule])
+            print(f"  \u26a0\ufe0f {rule} ({count}) — no auto-fixer")
+
+    ok = 0
+    errors = 0
+    for rule, (mod_path, fn_name) in sorted(fixers_to_run.items()):
+        count = len(df[df["Rule Name"].str.lower().str.strip() == rule])
+        if scan_only:
+            print(f"  [SCAN] Would run {fn_name}() for '{rule}' ({count} violation(s))")
+            ok += 1
+            continue
+        try:
+            mod = importlib.import_module(mod_path)
+            fn = getattr(mod, fn_name)
+            print(f"  \u25b6 Running {fn_name}() for '{rule}' ({count} violation(s))\u2026")
+            fn(dataset=dataset, workspace=workspace, scan_only=False)
+            ok += 1
+        except Exception as e:
+            print(f"  \u274c Error running {fn_name}(): {e}")
+            errors += 1
+
+    if scan_only:
+        print(f"\n{icons.info} Scan complete: {ok} fixer(s) would run.")
+    else:
+        summary = f"\n{icons.green_dot} Applied {ok} fixer(s)."
+        if errors:
+            summary = f"\n{icons.warning} {ok} OK, {errors} error(s)."
+        print(summary)

--- a/src/sempy_labs/_ui_components.py
+++ b/src/sempy_labs/_ui_components.py
@@ -1,0 +1,174 @@
+# Shared UI components for PBI Fixer explorer tabs.
+# Provides theme constants, icon definitions, tree-building utilities,
+# and reusable layout helpers for the Semantic Model and Report explorer tabs.
+
+import ipywidgets as widgets
+
+# ---------------------------------------------------------------------------
+# Theme constants (shared across all tabs)
+# ---------------------------------------------------------------------------
+FONT_FAMILY = "-apple-system,BlinkMacSystemFont,sans-serif"
+TEXT_COLOR = "inherit"
+BORDER_COLOR = "#e0e0e0"
+ICON_ACCENT = "#FF9500"
+GRAY_COLOR = "#999"
+SECTION_BG = "#fafafa"
+
+# ---------------------------------------------------------------------------
+# Icons for tree nodes (Unicode)
+# ---------------------------------------------------------------------------
+ICONS = {
+    "table": "\U0001F4C1",        # 📁
+    "column": "\U0001F4CF",        # 📏
+    "measure": "\U0001F4D0",       # 📐
+    "hierarchy": "\U0001F517",     # 🔗
+    "calc_group": "\U0001F4CA",    # 📊
+    "calc_item": "\u2022",         # •
+    "model": "\U0001F4C4",         # 📄 (document = semantic model)
+    "report": "\U0001F4CA",        # 📊 (chart = report)
+    "page": "\U0001F4C4",         # 📄
+    "visual": "\U0001F441",        # 👁
+    "partition": "\U0001F4CE",     # 📎
+    "folder": "\U0001F4C2",        # 📂
+    "relationship": "\u2194",      # ↔
+}
+
+# Collapse/expand markers
+EXPANDED = "\u25BC"   # ▼
+COLLAPSED = "\u25B6"  # ▶
+
+# Indentation string per level (using non-breaking spaces for Select widget)
+_INDENT = "\u00A0\u00A0\u00A0\u00A0"  # 4 nbsp per level
+
+
+def build_tree_items(items):
+    """
+    Build option list and reverse-lookup map for a widgets.Select tree.
+
+    Parameters
+    ----------
+    items : list[tuple[int, str, str, str]]
+        Each tuple is (indent_level, icon_key, display_label, object_key).
+        ``icon_key`` must be a key in ``ICONS`` or a literal character.
+        ``object_key`` is an opaque string used for reverse lookup.
+
+    Returns
+    -------
+    options : list[str]
+        Formatted strings for ``widgets.Select.options``.
+    key_map : dict[str, str]
+        Maps each formatted option string → its ``object_key``.
+    """
+    options = []
+    key_map = {}
+    seen = {}  # track duplicate display strings
+    for indent, icon_key, label, obj_key in items:
+        icon = ICONS.get(icon_key, icon_key)
+        formatted = f"{_INDENT * indent}{icon} {label}"
+        # Ensure uniqueness — append invisible counter for duplicates
+        if formatted in key_map:
+            count = seen.get(formatted, 1) + 1
+            seen[formatted] = count
+            # Use zero-width spaces to make string unique but visually identical
+            formatted = formatted + ("\u200b" * count)
+        options.append(formatted)
+        key_map[formatted] = obj_key
+    return options, key_map
+
+
+def create_three_panel_layout(tree_widget, preview_widget, properties_widget):
+    """
+    Create the three-panel explorer layout:
+    left = tree (fixed 280px), right = preview (top) + properties (bottom).
+
+    Returns a single HBox widget.
+    """
+    right_panel = widgets.VBox(
+        [preview_widget, properties_widget],
+        layout=widgets.Layout(
+            flex="1",
+            gap="8px",
+        ),
+    )
+    return widgets.HBox(
+        [tree_widget, right_panel],
+        layout=widgets.Layout(
+            width="100%",
+            gap="8px",
+        ),
+    )
+
+
+def create_connection_bar(*children):
+    """
+    Wrap connection-bar children (inputs, buttons, status) in a styled HBox.
+    """
+    return widgets.HBox(
+        list(children),
+        layout=widgets.Layout(
+            align_items="center",
+            gap="8px",
+            padding="8px 12px",
+            margin="0 0 8px 0",
+            border=f"1px solid {BORDER_COLOR}",
+            border_radius="8px",
+        ),
+    )
+
+
+def input_label(text):
+    """Small styled label for connection bar inputs."""
+    return widgets.HTML(
+        value=f'<span style="font-size:13px; font-weight:500; color:{TEXT_COLOR}; '
+        f"font-family:{FONT_FAMILY}; min-width:80px; display:inline-block;\">"
+        f"{text}</span>"
+    )
+
+
+def status_html(msg="", color=GRAY_COLOR):
+    """Returns a styled status HTML widget."""
+    w = widgets.HTML(value="")
+    if msg:
+        set_status(w, msg, color)
+    return w
+
+
+def set_status(widget, msg, color):
+    """Update a status HTML widget with a styled message."""
+    widget.value = (
+        f'<div style="padding:4px 8px; border-radius:6px; '
+        f"background:{color}1a; color:{color}; font-size:13px; "
+        f'font-family:{FONT_FAMILY};">{msg}</div>'
+    )
+
+
+def placeholder_panel(text, min_height="120px"):
+    """Gray placeholder panel for 'coming soon' sections."""
+    return widgets.HTML(
+        value=f'<div style="padding:16px; color:{GRAY_COLOR}; font-size:13px; '
+        f"font-family:{FONT_FAMILY}; text-align:center; "
+        f'font-style:italic;">{text}</div>',
+        layout=widgets.Layout(
+            border=f"1px solid {BORDER_COLOR}",
+            border_radius="8px",
+            min_height=min_height,
+            background_color=SECTION_BG,
+        ),
+    )
+
+
+def panel_box(children, flex="1", min_height=None):
+    """
+    Consistent styled panel (used for preview and properties boxes).
+    Ensures both panels have the same border, background, and radius.
+    """
+    layout_args = {
+        "flex": flex,
+        "border": f"1px solid {BORDER_COLOR}",
+        "border_radius": "8px",
+        "padding": "8px",
+        "background_color": SECTION_BG,
+    }
+    if min_height:
+        layout_args["min_height"] = min_height
+    return widgets.VBox(children, layout=widgets.Layout(**layout_args))

--- a/src/sempy_labs/report/__init__.py
+++ b/src/sempy_labs/report/__init__.py
@@ -28,6 +28,7 @@ from ._report_rebind import (
 )
 from ._report_bpa_rules import report_bpa_rules
 from ._report_bpa import run_report_bpa
+from ._fix_report_bpa import fix_report_bpa
 from ._export_report import (
     export_report,
 )
@@ -40,6 +41,10 @@ from ._upgrade_to_pbir import (
 from ._items import (
     list_reports,
     get_report,
+)
+from sempy_labs._pbi_fixer import (
+    pbi_fixer,
+    pbi_fixer_v2,
 )
 
 __all__ = [
@@ -58,6 +63,7 @@ __all__ = [
     "ReportWrapper",
     "report_bpa_rules",
     "run_report_bpa",
+    "fix_report_bpa",
     "get_report_datasources",
     "download_report",
     "save_report_as_pbip",
@@ -66,4 +72,6 @@ __all__ = [
     "upgrade_to_pbir",
     "list_reports",
     "get_report",
+    "pbi_fixer",
+    "pbi_fixer_v2",
 ]

--- a/src/sempy_labs/report/_fix_report_bpa.py
+++ b/src/sempy_labs/report/_fix_report_bpa.py
@@ -1,0 +1,110 @@
+# Fix Report BPA — Standalone function to scan Report BPA and auto-fix all fixable violations.
+# Runs run_report_bpa(), maps violations to standalone report fixer files, executes them.
+
+from uuid import UUID
+from typing import Optional
+from sempy._utils._log import log
+import sempy_labs._icons as icons
+
+
+# Mapping: Report BPA rule name (lowercased) → (module_path, function_name)
+_RULE_TO_FIXER = {
+    "remove custom visuals which are not used in the report": (
+        "sempy_labs.report._Fix_RemoveUnusedCustomVisuals", "fix_remove_unused_custom_visuals"),
+    "avoid setting 'show items with no data' on columns": (
+        "sempy_labs.report._Fix_DisableShowItemsNoData", "fix_disable_show_items_no_data"),
+    "move report-level measures into the semantic model.": (
+        "sempy_labs.report._Fix_MigrateReportLevelMeasures", "fix_migrate_report_level_measures"),
+    "avoid tall report pages with vertical scrolling": (
+        "sempy_labs.report._Fix_PageSize", "fix_page_size"),
+}
+
+
+@log
+def fix_report_bpa(
+    report: str | UUID,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+) -> None:
+    """
+    Scans Report BPA rules and auto-fixes all fixable violations using
+    standalone fixer scripts.
+
+    Parameters
+    ----------
+    report : str | uuid.UUID
+        Name or ID of the report.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports which fixers would run without applying changes.
+
+    Returns
+    -------
+    None
+    """
+    import importlib
+
+    from sempy_labs.report import run_report_bpa
+    import IPython.display as _ipd
+    _orig_display = _ipd.display
+    _ipd.display = lambda *a, **kw: None
+    try:
+        df = run_report_bpa(report=report, workspace=workspace, return_dataframe=True)
+    finally:
+        _ipd.display = _orig_display
+
+    if df is None or len(df) == 0:
+        print(f"{icons.green_dot} No Report BPA violations found for '{report}'.")
+        return
+
+    # Determine which fixers are needed
+    violated_rules = set(df["Rule Name"].str.lower().str.strip().unique())
+    fixers_to_run = {}
+    for rule in violated_rules:
+        if rule in _RULE_TO_FIXER:
+            mod_path, fn_name = _RULE_TO_FIXER[rule]
+            fixers_to_run[rule] = (mod_path, fn_name)
+
+    unfixable = violated_rules - set(fixers_to_run.keys())
+
+    if not fixers_to_run:
+        print(f"{icons.info} {len(df)} violation(s) found but none have auto-fixers.")
+        for rule in sorted(violated_rules):
+            count = len(df[df["Rule Name"].str.lower().str.strip() == rule])
+            print(f"  \u2022 {rule} ({count} violation(s)) \u2014 no auto-fixer")
+        return
+
+    print(f"{icons.info} {len(df)} violation(s) across {len(violated_rules)} rule(s). "
+          f"{len(fixers_to_run)} fixable, {len(unfixable)} informational.")
+
+    if unfixable:
+        for rule in sorted(unfixable):
+            count = len(df[df["Rule Name"].str.lower().str.strip() == rule])
+            print(f"  \u26a0\ufe0f {rule} ({count}) \u2014 no auto-fixer")
+
+    ok = 0
+    errors = 0
+    for rule, (mod_path, fn_name) in sorted(fixers_to_run.items()):
+        count = len(df[df["Rule Name"].str.lower().str.strip() == rule])
+        if scan_only:
+            print(f"  [SCAN] Would run {fn_name}() for '{rule}' ({count} violation(s))")
+            ok += 1
+            continue
+        try:
+            mod = importlib.import_module(mod_path)
+            fn = getattr(mod, fn_name)
+            print(f"  \u25b6 Running {fn_name}() for '{rule}' ({count} violation(s))\u2026")
+            fn(report=report, workspace=workspace, scan_only=False)
+            ok += 1
+        except Exception as e:
+            print(f"  \u274c Error running {fn_name}(): {e}")
+            errors += 1
+
+    if scan_only:
+        print(f"\n{icons.info} Scan complete: {ok} fixer(s) would run.")
+    else:
+        summary = f"\n{icons.green_dot} Applied {ok} fixer(s)."
+        if errors:
+            summary = f"\n{icons.warning} {ok} OK, {errors} error(s)."
+        print(summary)

--- a/src/sempy_labs/report/_report_helper.py
+++ b/src/sempy_labs/report/_report_helper.py
@@ -56,7 +56,7 @@ vis_type_mapping = {
 
 def generate_visual_file_path(page_file_path: str, visual_id: str) -> str:
 
-    return page_file_path.split("/page.json")[0] + f"/visuals/{visual_id}.json"
+    return page_file_path.split("/page.json")[0] + f"/visuals/{visual_id}/visual.json"
 
 
 def resolve_visual_type(visual_type: str) -> str:

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -6,6 +6,9 @@ from ._copilot import (
 from ._caching import (
     enable_query_caching,
 )
+from ._Add_CacheWarming import (
+    add_cache_warming,
+)
 
 
 __all__ = [
@@ -13,4 +16,5 @@ __all__ = [
     "set_endorsement",
     "make_discoverable",
     "enable_query_caching",
+    "add_cache_warming",
 ]


### PR DESCRIPTION
## PBI Fixer — Shared UI Components

Shared UI infrastructure used by the PBI Fixer application: theme constants, icon sets, tree-building utilities, layout helpers, and the BPA scan runner modules for both reports and semantic models. These are the foundational components that the main PBI Fixer UI (PR #22) builds on.

### Components

| Module | Description |
|--------|-------------|
| `_ui_components.py` | Shared theme (colors, fonts, spacing), icon emoji sets, tree-building helpers for `SelectMultiple` widgets, layout utility functions. |
| `_fix_model_bpa.py` | BPA scan runner for semantic models — orchestrates running all SM fixers in scan_only mode and collecting results. |
| `report/_fix_report_bpa.py` | BPA scan runner for reports — orchestrates running all report fixers in scan_only mode and collecting results. |
| `report/_report_helper.py` | Report utility functions used by the Report Explorer (page/visual parsing, field extraction, etc.). |
| `report/__init__.py` | Updated exports for report-level components. |
| `semantic_model/__init__.py` | Updated exports for SM-level components. |

### Files

- `src/sempy_labs/_ui_components.py` (new file)
- `src/sempy_labs/_fix_model_bpa.py` (new file)
- `src/sempy_labs/report/_fix_report_bpa.py` (new file)
- `src/sempy_labs/report/_report_helper.py` (new file)
- `src/sempy_labs/report/__init__.py` (updated exports)
- `src/sempy_labs/semantic_model/__init__.py` (updated exports)

### Notes

- This PR adds new files only — no existing SLL code is modified.
- The BPA runners use lazy imports — they gracefully skip any fixer function that isn't yet available (e.g., if Phase 1–4 PRs haven't been merged yet).
- This is a prerequisite for PR #22 (the main PBI Fixer UI).

---

## PBI Fixer Contribution — Overview

This PR is part of the **PBI Fixer** contribution to semantic-link-labs — an interactive ipywidgets-based UI for scanning and fixing Power BI reports and semantic models directly in Microsoft Fabric Notebooks.

The PBI Fixer provides a tabbed ipywidgets interface (Semantic Model Explorer, Report Explorer, Perspective Editor, Vertipaq Analyzer) that lets users interactively scan, inspect, and fix Power BI artifacts without leaving the notebook. All underlying fixer functions also work as standalone API calls, so users can integrate them into scripts and pipelines without the UI.

### Contribution Structure

The full contribution (~17K lines across 68 files) is split into **22 focused PRs across 6 phases** to keep each PR reviewable and self-contained. Only new files are added in Phases 1–4 and 6 — no existing SLL code is modified.

| Phase | Focus | PRs | Description |
|-------|-------|-----|-------------|
| **1** | **Report Fixers** | 7 | Standalone functions that programmatically fix common Power BI report issues: replace pie charts with bar charts, standardize page sizes to Full HD, apply chart formatting best practices, migrate slicers to slicerbars, hide visual-level filters, clean up unused custom visuals, align visuals, migrate report-level measures, and upgrade reports to PBIR format. Each function operates on PBIR-format report definitions. |
| **2** | **Semantic Model Fixers** | 4 | Functions that fix and enhance semantic models via XMLA/TOM: add calculated calendar and measure tables, add calculation groups for units and time intelligence, discourage implicit measures, and 19 BPA auto-fixers covering formatting conventions, naming standards, data types, column visibility, sort order, and DAX patterns (e.g., use DIVIDE instead of `/`). |
| **3** | **SM Setup & Analysis** | 3 | Setup utilities: configure cache warming queries, set up incremental refresh policies, and prepare semantic models for AI/Copilot integration (descriptions, metadata enrichment). |
| **4** | **Report Utilities** | 3 | Report-level utilities: auto-generate report page prototypes from a semantic model's structure, extract and apply report themes, and generate IBCS-compliant variance charts. |
| **5** | **Upstream Enhancements** | 3 | **⚠️ These PRs modify existing SLL code** (unlike Phases 1–4 which only add new files). Changes include TOM model `.Find()` fixes and expression capture (`tom/_model.py`), Vertipaq analyzer enhancements with memory/column-level analysis (`_vertipaq.py`, ~1000 lines changed), and various small fixes across `_items.py`, `_item_recovery.py`, `_helper_functions.py`, `_export_report.py`, `_sql.py`, and `admin/_tenant.py`. These carry higher merge conflict risk and may need closer review or discussion. |
| **6** | **PBI Fixer UI** | 2 | The interactive UI layer: shared UI components (theme, icons, tree builders, layout helpers), BPA scan runners, report helpers, and the main PBI Fixer application with its tabbed interface (SM Explorer, Report Explorer, Perspective Editor, Vertipaq Analyzer). Depends on Phases 1–5 but uses lazy imports to degrade gracefully if individual fixers aren't yet merged. |

### Dependencies & Review Order

- **Phases 1–4** are fully independent — they only add new files and can be reviewed/merged in any order.
- **Phase 5** is also independent but modifies existing code, so it may benefit from early discussion.
- **Phase 6** (the UI) ties everything together. It depends on the earlier phases but works standalone via lazy imports.
- All fixer functions work without the UI — they can be called directly as `sempy_labs.report.fix_piecharts(...)` or `sempy_labs.semantic_model.add_calculated_calendar(...)`.
