### PR TITLE
[pbi-fixer] Add fix_migrate_report_level_measures: migrate report-level measures into the underlying semantic model

### DIFF
--- a/src/sempy_labs/report/_Fix_MigrateReportLevelMeasures.py
+++ b/src/sempy_labs/report/_Fix_MigrateReportLevelMeasures.py
@@ -1,0 +1,74 @@
+# Migrate Report-Level Measures to Semantic Model
+# Moves report-level measures from the report into the underlying semantic model.
+
+from uuid import UUID
+from typing import Optional
+from sempy._utils._log import log
+import sempy_labs._icons as icons
+from sempy_labs.report._reportwrapper import connect_report
+
+
+@log
+def fix_migrate_report_level_measures(
+    report: str | UUID,
+    page_name: Optional[str] = None,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+) -> None:
+    """
+    Migrates report-level measures from the report into the semantic model.
+    It is a best practice to keep measures defined in the semantic model,
+    not in the report.
+
+    Parameters
+    ----------
+    report : str | uuid.UUID
+        Name or ID of the report.
+    page_name : str, default=None
+        Ignored (report-level measures are report-wide). Kept for API consistency.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+        Defaults to None which resolves to the workspace of the attached lakehouse
+        or if no lakehouse attached, resolves to the workspace of the notebook.
+    scan_only : bool, default=False
+        If True, only scans and reports which report-level measures exist
+        without migrating them.
+
+    Returns
+    -------
+    None
+    """
+
+    with connect_report(
+        report=report, workspace=workspace, readonly=scan_only, show_diffs=False
+    ) as rw:
+        if rw.format != "PBIR":
+            print(
+                f"{icons.red_dot} Report '{rw._report_name}' is in '{rw.format}' format, not PBIR. "
+                f"Run 'Upgrade to PBIR' first."
+            )
+            return
+
+        dfRLM = rw.list_report_level_measures()
+
+        if dfRLM.empty:
+            print("No report-level measures found. 0 changes needed.")
+            return
+
+        for _, row in dfRLM.iterrows():
+            measure_name = row.get("Measure Name", "")
+            table_name = row.get("Table Name", "")
+            if scan_only:
+                print(f"[SCAN] Report-level measure: [{table_name}].[{measure_name}]")
+            else:
+                print(f"Migrating report-level measure: [{table_name}].[{measure_name}]")
+
+    if not scan_only:
+        # Re-open in write mode to actually migrate
+        with connect_report(
+            report=report, workspace=workspace, readonly=False, show_diffs=False
+        ) as rw:
+            rw.migrate_report_level_measures()
+            print(f"{icons.green_dot} Migrated {len(dfRLM)} report-level measure(s) to the semantic model.")
+    else:
+        print(f"{len(dfRLM)} report-level measure(s) found.")

--- a/src/sempy_labs/report/_Fix_MigrateReportLevelMeasures.py
+++ b/src/sempy_labs/report/_Fix_MigrateReportLevelMeasures.py
@@ -17,6 +17,8 @@ def fix_migrate_report_level_measures(
 ) -> None:
     """
     Migrates report-level measures from the report into the semantic model.
+
+    Note: The current implementation does not preserve the `Data Category` of report-level measures (e.g. Web URL, Image URL); these will be reset to default after migration.
     It is a best practice to keep measures defined in the semantic model,
     not in the report.
 

--- a/src/sempy_labs/report/__init__.py
+++ b/src/sempy_labs/report/__init__.py
@@ -41,6 +41,7 @@ from ._items import (
     list_reports,
     get_report,
 )
+from ._Fix_MigrateReportLevelMeasures import fix_migrate_report_level_measures
 
 __all__ = [
     "create_report_from_reportjson",
@@ -66,7 +67,5 @@ __all__ = [
     "upgrade_to_pbir",
     "list_reports",
     "get_report",
+    "fix_migrate_report_level_measures",
 ]
-
-from ._Fix_MigrateReportLevelMeasures import fix_migrate_report_level_measures
-__all__ += ["fix_migrate_report_level_measures"]

--- a/src/sempy_labs/report/__init__.py
+++ b/src/sempy_labs/report/__init__.py
@@ -67,3 +67,6 @@ __all__ = [
     "list_reports",
     "get_report",
 ]
+
+from ._Fix_MigrateReportLevelMeasures import fix_migrate_report_level_measures
+__all__ += ["fix_migrate_report_level_measures"]


### PR DESCRIPTION
Adds a sempy_labs fixer `fix_migrate_report_level_measures()` that migrate report-level measures into the underlying semantic model.

Adds **one** source file (`src/sempy_labs/report/_Fix_MigrateReportLevelMeasures.py`) plus one re-export line in the matching `__init__.py`. No other files touched, no shared helpers, no dependency on any other PR.

**Part of the PBI Fixer contribution.** Tracking issue: #1185
