### PR TITLE
[pbi-fixer] Add fix_capitalize_object_names: capitalize first letter of object names

### DIFF
--- a/src/sempy_labs/semantic_model/_Fix_CapitalizeObjectNames.py
+++ b/src/sempy_labs/semantic_model/_Fix_CapitalizeObjectNames.py
@@ -1,0 +1,72 @@
+# Fix "First letter of objects must be capitalized" — standalone BPA fixer.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_capitalize_object_names(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Capitalizes the first letter of table, column, measure, hierarchy, and partition names.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    def _cap(name):
+        return name[0].upper() + name[1:] if name and name[0] != name[0].upper() else None
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            new_name = _cap(table.Name)
+            if new_name:
+                if scan_only:
+                    print(f"  Would capitalize table: '{table.Name}' → '{new_name}'")
+                else:
+                    table.Name = new_name
+                    print(f"  Capitalized table: '{new_name}'")
+                fixed += 1
+            for col in table.Columns:
+                new_name = _cap(col.Name)
+                if new_name:
+                    if scan_only:
+                        print(f"  Would capitalize column: '{table.Name}'[{col.Name}]")
+                    else:
+                        col.Name = new_name
+                        print(f"  Capitalized column: '{table.Name}'[{new_name}]")
+                    fixed += 1
+            for m in table.Measures:
+                new_name = _cap(m.Name)
+                if new_name:
+                    if scan_only:
+                        print(f"  Would capitalize measure: [{m.Name}]")
+                    else:
+                        m.Name = new_name
+                        print(f"  Capitalized measure: [{new_name}]")
+                    fixed += 1
+            for h in table.Hierarchies:
+                new_name = _cap(h.Name)
+                if new_name:
+                    if scan_only:
+                        print(f"  Would capitalize hierarchy: {h.Name}")
+                    else:
+                        h.Name = new_name
+                        print(f"  Capitalized hierarchy: {new_name}")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would capitalize" if scan_only else "Capitalized"
+    print(f"  {action} {fixed} object name(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_CapitalizeObjectNames.py
+++ b/src/sempy_labs/semantic_model/_Fix_CapitalizeObjectNames.py
@@ -7,21 +7,26 @@ from sempy._utils._log import log
 
 @log
 def fix_capitalize_object_names(
-    dataset: str,
+    dataset: str | UUID,
     workspace: Optional[str | UUID] = None,
     scan_only: bool = False,
-):
+) -> int:
     """
-    Capitalizes the first letter of table, column, measure, hierarchy, and partition names.
+    Capitalizes the first letter of table, column, measure, hierarchy.
 
     Parameters
     ----------
-    dataset : str
-        Name of the semantic model.
+    dataset : str | UUID
+        Name or ID of the semantic model.
     workspace : str | uuid.UUID, default=None
         The Fabric workspace name or ID.
     scan_only : bool, default=False
         If True, only reports what would be fixed without making changes.
+
+    Returns
+    -------
+    int
+        Number of items fixed.
     """
     from sempy_labs.tom import connect_semantic_model
 

--- a/src/sempy_labs/semantic_model/_Fix_CapitalizeObjectNames.py
+++ b/src/sempy_labs/semantic_model/_Fix_CapitalizeObjectNames.py
@@ -2,8 +2,10 @@
 
 from typing import Optional
 from uuid import UUID
+from sempy._utils._log import log
 
 
+@log
 def fix_capitalize_object_names(
     dataset: str,
     workspace: Optional[str | UUID] = None,
@@ -64,8 +66,6 @@ def fix_capitalize_object_names(
                         h.Name = new_name
                         print(f"  Capitalized hierarchy: {new_name}")
                     fixed += 1
-        if not scan_only and fixed > 0:
-            tom.model.SaveChanges()
 
     action = "Would capitalize" if scan_only else "Capitalized"
     print(f"  {action} {fixed} object name(s).")

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -13,3 +13,6 @@ __all__ = [
     "make_discoverable",
     "enable_query_caching",
 ]
+
+from ._Fix_CapitalizeObjectNames import fix_capitalize_object_names
+__all__ += ["fix_capitalize_object_names"]

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -6,13 +6,12 @@ from ._copilot import (
 from ._caching import (
     enable_query_caching,
 )
+from ._Fix_CapitalizeObjectNames import fix_capitalize_object_names
 
 __all__ = [
     "approved_for_copilot",
     "set_endorsement",
     "make_discoverable",
     "enable_query_caching",
+    "fix_capitalize_object_names",
 ]
-
-from ._Fix_CapitalizeObjectNames import fix_capitalize_object_names
-__all__ += ["fix_capitalize_object_names"]


### PR DESCRIPTION
Adds a sempy_labs fixer `fix_capitalize_object_names()` that capitalize first letter of object names.

Adds **one** source file (`src/sempy_labs/semantic_model/_Fix_CapitalizeObjectNames.py`) plus one re-export line in the matching `__init__.py`. No other files touched, no shared helpers, no dependency on any other PR.

**Part of the PBI Fixer contribution.** Tracking issue: #1185
