### PR TITLE
[pbi-fixer] Add fix_trim_object_names: trim leading/trailing whitespace from object names

### DIFF
--- a/src/sempy_labs/semantic_model/_Fix_TrimObjectNames.py
+++ b/src/sempy_labs/semantic_model/_Fix_TrimObjectNames.py
@@ -1,0 +1,77 @@
+# Fix "Objects should not start or end with a space" — standalone BPA fixer.
+# Trims leading/trailing whitespace from object names.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_trim_object_names(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Trims leading/trailing whitespace from table, column, measure, hierarchy, and partition names.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            if table.Name != table.Name.strip():
+                if scan_only:
+                    print(f"  Would trim table: '{table.Name}'")
+                else:
+                    table.Name = table.Name.strip()
+                    print(f"  Trimmed table: '{table.Name}'")
+                fixed += 1
+            for col in table.Columns:
+                if col.Name != col.Name.strip():
+                    if scan_only:
+                        print(f"  Would trim column: '{table.Name}'[{col.Name}]")
+                    else:
+                        col.Name = col.Name.strip()
+                        print(f"  Trimmed column: '{table.Name}'[{col.Name}]")
+                    fixed += 1
+            for m in table.Measures:
+                if m.Name != m.Name.strip():
+                    if scan_only:
+                        print(f"  Would trim measure: [{m.Name}]")
+                    else:
+                        m.Name = m.Name.strip()
+                        print(f"  Trimmed measure: [{m.Name}]")
+                    fixed += 1
+            for h in table.Hierarchies:
+                if h.Name != h.Name.strip():
+                    if scan_only:
+                        print(f"  Would trim hierarchy: {h.Name}")
+                    else:
+                        h.Name = h.Name.strip()
+                        print(f"  Trimmed hierarchy: {h.Name}")
+                    fixed += 1
+            try:
+                for p in table.Partitions:
+                    if p.Name != p.Name.strip():
+                        if scan_only:
+                            print(f"  Would trim partition: {p.Name}")
+                        else:
+                            p.Name = p.Name.strip()
+                            print(f"  Trimmed partition: {p.Name}")
+                        fixed += 1
+            except Exception:
+                pass
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would trim" if scan_only else "Trimmed"
+    print(f"  {action} {fixed} object name(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_TrimObjectNames.py
+++ b/src/sempy_labs/semantic_model/_Fix_TrimObjectNames.py
@@ -3,8 +3,10 @@
 
 from typing import Optional
 from uuid import UUID
+from sempy._utils._log import log
 
 
+@log
 def fix_trim_object_names(
     dataset: str,
     workspace: Optional[str | UUID] = None,
@@ -69,8 +71,6 @@ def fix_trim_object_names(
                         fixed += 1
             except Exception:
                 pass
-        if not scan_only and fixed > 0:
-            tom.model.SaveChanges()
 
     action = "Would trim" if scan_only else "Trimmed"
     print(f"  {action} {fixed} object name(s).")

--- a/src/sempy_labs/semantic_model/_Fix_TrimObjectNames.py
+++ b/src/sempy_labs/semantic_model/_Fix_TrimObjectNames.py
@@ -8,21 +8,26 @@ from sempy._utils._log import log
 
 @log
 def fix_trim_object_names(
-    dataset: str,
+    dataset: str | UUID,
     workspace: Optional[str | UUID] = None,
     scan_only: bool = False,
-):
+) -> int:
     """
     Trims leading/trailing whitespace from table, column, measure, hierarchy, and partition names.
 
     Parameters
     ----------
-    dataset : str
-        Name of the semantic model.
+    dataset : str | UUID
+        Name or ID of the semantic model.
     workspace : str | uuid.UUID, default=None
         The Fabric workspace name or ID.
     scan_only : bool, default=False
         If True, only reports what would be fixed without making changes.
+
+    Returns
+    -------
+    int
+        Number of items fixed.
     """
     from sempy_labs.tom import connect_semantic_model
 
@@ -69,8 +74,8 @@ def fix_trim_object_names(
                             p.Name = p.Name.strip()
                             print(f"  Trimmed partition: {p.Name}")
                         fixed += 1
-            except Exception:
-                pass
+            except (AttributeError, RuntimeError) as e:
+                print(f\"  Skipped (error: {e})\")
 
     action = "Would trim" if scan_only else "Trimmed"
     print(f"  {action} {fixed} object name(s).")

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -6,13 +6,12 @@ from ._copilot import (
 from ._caching import (
     enable_query_caching,
 )
+from ._Fix_TrimObjectNames import fix_trim_object_names
 
 __all__ = [
     "approved_for_copilot",
     "set_endorsement",
     "make_discoverable",
     "enable_query_caching",
+    "fix_trim_object_names",
 ]
-
-from ._Fix_TrimObjectNames import fix_trim_object_names
-__all__ += ["fix_trim_object_names"]

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -13,3 +13,6 @@ __all__ = [
     "make_discoverable",
     "enable_query_caching",
 ]
+
+from ._Fix_TrimObjectNames import fix_trim_object_names
+__all__ += ["fix_trim_object_names"]


### PR DESCRIPTION
Adds a sempy_labs fixer `fix_trim_object_names()` that trim leading/trailing whitespace from object names.

Adds **one** source file (`src/sempy_labs/semantic_model/_Fix_TrimObjectNames.py`) plus one re-export line in the matching `__init__.py`. No other files touched, no shared helpers, no dependency on any other PR.

**Part of the PBI Fixer contribution.** Tracking issue: #1185
