### PR TITLE
[pbi-fixer] Add fix_date_column_format: set consistent format string on Date columns

### DIFF
--- a/src/sempy_labs/semantic_model/_Fix_DateColumnFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_DateColumnFormat.py
@@ -1,0 +1,44 @@
+# Fix date column format — standalone BPA fixer.
+# Sets format string for columns named 'Date' to mm/dd/yyyy.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_date_column_format(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets the format string of 'Date' columns to mm/dd/yyyy.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            for col in table.Columns:
+                name_lower = col.Name.lower()
+                if name_lower == "date" and (not col.FormatString or str(col.FormatString).strip() == ""):
+                    if scan_only:
+                        print(f"  Would fix: '{table.Name}'[{col.Name}] → mm/dd/yyyy")
+                    else:
+                        col.FormatString = "mm/dd/yyyy"
+                        print(f"  Fixed: '{table.Name}'[{col.Name}] → mm/dd/yyyy")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} date column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_DateColumnFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_DateColumnFormat.py
@@ -3,8 +3,10 @@
 
 from typing import Optional
 from uuid import UUID
+from sempy._utils._log import log
 
 
+@log
 def fix_date_column_format(
     dataset: str,
     workspace: Optional[str | UUID] = None,
@@ -36,8 +38,6 @@ def fix_date_column_format(
                         col.FormatString = "mm/dd/yyyy"
                         print(f"  Fixed: '{table.Name}'[{col.Name}] → mm/dd/yyyy")
                     fixed += 1
-        if not scan_only and fixed > 0:
-            tom.model.SaveChanges()
 
     action = "Would fix" if scan_only else "Fixed"
     print(f"  {action} {fixed} date column(s).")

--- a/src/sempy_labs/semantic_model/_Fix_DateColumnFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_DateColumnFormat.py
@@ -8,21 +8,26 @@ from sempy._utils._log import log
 
 @log
 def fix_date_column_format(
-    dataset: str,
+    dataset: str | UUID,
     workspace: Optional[str | UUID] = None,
     scan_only: bool = False,
-):
+) -> int:
     """
     Sets the format string of 'Date' columns to mm/dd/yyyy.
 
     Parameters
     ----------
-    dataset : str
-        Name of the semantic model.
+    dataset : str | UUID
+        Name or ID of the semantic model.
     workspace : str | uuid.UUID, default=None
         The Fabric workspace name or ID.
     scan_only : bool, default=False
         If True, only reports what would be fixed without making changes.
+
+    Returns
+    -------
+    int
+        Number of items fixed.
     """
     from sempy_labs.tom import connect_semantic_model
 

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -13,3 +13,6 @@ __all__ = [
     "make_discoverable",
     "enable_query_caching",
 ]
+
+from ._Fix_DateColumnFormat import fix_date_column_format
+__all__ += ["fix_date_column_format"]

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -6,13 +6,12 @@ from ._copilot import (
 from ._caching import (
     enable_query_caching,
 )
+from ._Fix_DateColumnFormat import fix_date_column_format
 
 __all__ = [
     "approved_for_copilot",
     "set_endorsement",
     "make_discoverable",
     "enable_query_caching",
+    "fix_date_column_format",
 ]
-
-from ._Fix_DateColumnFormat import fix_date_column_format
-__all__ += ["fix_date_column_format"]


### PR DESCRIPTION
Adds a sempy_labs fixer `fix_date_column_format()` that set consistent format string on Date columns.

Adds **one** source file (`src/sempy_labs/semantic_model/_Fix_DateColumnFormat.py`) plus one re-export line in the matching `__init__.py`. No other files touched, no shared helpers, no dependency on any other PR.

**Part of the PBI Fixer contribution.** Tracking issue: #1185
