### PR TITLE
[pbi-fixer] Add fix_flag_column_format: format integer flag columns as Yes/No

### DIFF
--- a/src/sempy_labs/semantic_model/_Fix_FlagColumnFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_FlagColumnFormat.py
@@ -1,0 +1,57 @@
+# Fix "Format flag columns as Yes/No value strings" — standalone BPA fixer.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_flag_column_format(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets a Yes/No format on integer flag columns (names starting with 'Is' or ending with 'Flag').
+
+    Uses the DAX format string '"Yes";"Yes";"No"' pattern.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    _FLAG_FMT = '"Yes";"Yes";"No"'
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        import Microsoft.AnalysisServices.Tabular as TOM
+
+        for table in tom.model.Tables:
+            for col in table.Columns:
+                if col.IsHidden or table.IsHidden:
+                    continue
+                if col.DataType != TOM.DataType.Int64:
+                    continue
+                name = col.Name
+                if not (name.lower().startswith("is") or name.lower().endswith("flag") or name.lower().endswith(" flag")):
+                    continue
+                current_fmt = str(col.FormatString) if col.FormatString else ""
+                if current_fmt.strip():
+                    continue
+                if scan_only:
+                    print(f"  Would fix: '{table.Name}'[{col.Name}] → Yes/No format")
+                else:
+                    col.FormatString = _FLAG_FMT
+                    print(f"  Fixed: '{table.Name}'[{col.Name}] → Yes/No format")
+                fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} flag column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_FlagColumnFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_FlagColumnFormat.py
@@ -2,8 +2,10 @@
 
 from typing import Optional
 from uuid import UUID
+from sempy._utils._log import log
 
 
+@log
 def fix_flag_column_format(
     dataset: str,
     workspace: Optional[str | UUID] = None,
@@ -49,8 +51,6 @@ def fix_flag_column_format(
                     col.FormatString = _FLAG_FMT
                     print(f"  Fixed: '{table.Name}'[{col.Name}] → Yes/No format")
                 fixed += 1
-        if not scan_only and fixed > 0:
-            tom.model.SaveChanges()
 
     action = "Would fix" if scan_only else "Fixed"
     print(f"  {action} {fixed} flag column(s).")

--- a/src/sempy_labs/semantic_model/_Fix_FlagColumnFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_FlagColumnFormat.py
@@ -7,10 +7,10 @@ from sempy._utils._log import log
 
 @log
 def fix_flag_column_format(
-    dataset: str,
+    dataset: str | UUID,
     workspace: Optional[str | UUID] = None,
     scan_only: bool = False,
-):
+) -> int:
     """
     Sets a Yes/No format on integer flag columns (names starting with 'Is' or ending with 'Flag').
 
@@ -18,12 +18,17 @@ def fix_flag_column_format(
 
     Parameters
     ----------
-    dataset : str
-        Name of the semantic model.
+    dataset : str | UUID
+        Name or ID of the semantic model.
     workspace : str | uuid.UUID, default=None
         The Fabric workspace name or ID.
     scan_only : bool, default=False
         If True, only reports what would be fixed without making changes.
+
+    Returns
+    -------
+    int
+        Number of items fixed.
     """
     from sempy_labs.tom import connect_semantic_model
 

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -6,13 +6,12 @@ from ._copilot import (
 from ._caching import (
     enable_query_caching,
 )
+from ._Fix_FlagColumnFormat import fix_flag_column_format
 
 __all__ = [
     "approved_for_copilot",
     "set_endorsement",
     "make_discoverable",
     "enable_query_caching",
+    "fix_flag_column_format",
 ]
-
-from ._Fix_FlagColumnFormat import fix_flag_column_format
-__all__ += ["fix_flag_column_format"]

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -13,3 +13,6 @@ __all__ = [
     "make_discoverable",
     "enable_query_caching",
 ]
+
+from ._Fix_FlagColumnFormat import fix_flag_column_format
+__all__ += ["fix_flag_column_format"]


### PR DESCRIPTION
Adds a sempy_labs fixer `fix_flag_column_format()` that format integer flag columns as Yes/No.

Adds **one** source file (`src/sempy_labs/semantic_model/_Fix_FlagColumnFormat.py`) plus one re-export line in the matching `__init__.py`. No other files touched, no shared helpers, no dependency on any other PR.

**Part of the PBI Fixer contribution.** Tracking issue: #1185
