### PR TITLE
[pbi-fixer] Add fix_percentage_format: set percentage format on % / Pct measures

### DIFF
--- a/src/sempy_labs/semantic_model/_Fix_PercentageFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_PercentageFormat.py
@@ -1,0 +1,50 @@
+# Fix "Percentages should be formatted with thousands separators" — standalone BPA fixer.
+
+from typing import Optional
+from uuid import UUID
+import re
+
+
+def fix_percentage_format(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets format string on measures whose name contains %, Percent, or Pct.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    _PCT_FMT = "#,0.0%;-#,0.0%;#,0.0%"
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            for m in table.Measures:
+                name_lower = m.Name.lower()
+                if not any(k in name_lower for k in ("%", "percent", "pct")):
+                    continue
+                current_fmt = str(m.FormatString) if m.FormatString else ""
+                if "%" in current_fmt:
+                    continue  # already has a percentage format
+                if scan_only:
+                    print(f"  Would fix: [{m.Name}] → {_PCT_FMT}")
+                else:
+                    m.FormatString = _PCT_FMT
+                    print(f"  Fixed: [{m.Name}] → {_PCT_FMT}")
+                fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} percentage measure(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_PercentageFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_PercentageFormat.py
@@ -3,8 +3,10 @@
 from typing import Optional
 from uuid import UUID
 import re
+from sempy._utils._log import log
 
 
+@log
 def fix_percentage_format(
     dataset: str,
     workspace: Optional[str | UUID] = None,
@@ -42,8 +44,6 @@ def fix_percentage_format(
                     m.FormatString = _PCT_FMT
                     print(f"  Fixed: [{m.Name}] → {_PCT_FMT}")
                 fixed += 1
-        if not scan_only and fixed > 0:
-            tom.model.SaveChanges()
 
     action = "Would fix" if scan_only else "Fixed"
     print(f"  {action} {fixed} percentage measure(s).")

--- a/src/sempy_labs/semantic_model/_Fix_PercentageFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_PercentageFormat.py
@@ -8,21 +8,26 @@ from sempy._utils._log import log
 
 @log
 def fix_percentage_format(
-    dataset: str,
+    dataset: str | UUID,
     workspace: Optional[str | UUID] = None,
     scan_only: bool = False,
-):
+) -> int:
     """
     Sets format string on measures whose name contains %, Percent, or Pct.
 
     Parameters
     ----------
-    dataset : str
-        Name of the semantic model.
+    dataset : str | UUID
+        Name or ID of the semantic model.
     workspace : str | uuid.UUID, default=None
         The Fabric workspace name or ID.
     scan_only : bool, default=False
         If True, only reports what would be fixed without making changes.
+
+    Returns
+    -------
+    int
+        Number of items fixed.
     """
     from sempy_labs.tom import connect_semantic_model
 

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -6,13 +6,12 @@ from ._copilot import (
 from ._caching import (
     enable_query_caching,
 )
+from ._Fix_PercentageFormat import fix_percentage_format
 
 __all__ = [
     "approved_for_copilot",
     "set_endorsement",
     "make_discoverable",
     "enable_query_caching",
+    "fix_percentage_format",
 ]
-
-from ._Fix_PercentageFormat import fix_percentage_format
-__all__ += ["fix_percentage_format"]

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -13,3 +13,6 @@ __all__ = [
     "make_discoverable",
     "enable_query_caching",
 ]
+
+from ._Fix_PercentageFormat import fix_percentage_format
+__all__ += ["fix_percentage_format"]


### PR DESCRIPTION
Adds a sempy_labs fixer `fix_percentage_format()` that set percentage format on % / Pct measures.

Adds **one** source file (`src/sempy_labs/semantic_model/_Fix_PercentageFormat.py`) plus one re-export line in the matching `__init__.py`. No other files touched, no shared helpers, no dependency on any other PR.

**Part of the PBI Fixer contribution.** Tracking issue: #1185
