### PR TITLE
[pbi-fixer] Add fix_whole_number_format: set #,0 format on integer measures

### DIFF
--- a/src/sempy_labs/semantic_model/_Fix_WholeNumberFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_WholeNumberFormat.py
@@ -1,0 +1,51 @@
+# Fix "Whole numbers should be formatted with thousands separators" — standalone BPA fixer.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_whole_number_format(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets format string to #,0 on integer-typed measures without a format string.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        import Microsoft.AnalysisServices.Tabular as TOM
+
+        for table in tom.model.Tables:
+            for m in table.Measures:
+                fmt = str(m.FormatString) if m.FormatString else ""
+                if fmt.strip():
+                    continue  # already has a format
+                # Check if the measure likely returns an integer
+                # (heuristic: name doesn't suggest % or ratio)
+                name_lower = m.Name.lower()
+                if any(k in name_lower for k in ("%", "percent", "pct", "ratio", "rate")):
+                    continue
+                if scan_only:
+                    print(f"  Would fix: [{m.Name}] → #,0")
+                else:
+                    m.FormatString = "#,0"
+                    print(f"  Fixed: [{m.Name}] → #,0")
+                fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} measure(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_WholeNumberFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_WholeNumberFormat.py
@@ -5,22 +5,27 @@ from uuid import UUID
 
 
 def fix_whole_number_format(
-    dataset: str,
+    dataset: str | UUID,
     workspace: Optional[str | UUID] = None,
     scan_only: bool = False,
-):
+) -> int:
     """
     Sets format string to #,0 on integer-typed measures (DataType=Int64) that
     have neither a static FormatString nor a dynamic FormatStringDefinition.
 
     Parameters
     ----------
-    dataset : str
-        Name of the semantic model.
+    dataset : str | UUID
+        Name or ID of the semantic model.
     workspace : str | uuid.UUID, default=None
         The Fabric workspace name or ID.
     scan_only : bool, default=False
         If True, only reports what would be fixed without making changes.
+
+    Returns
+    -------
+    int
+        Number of items fixed.
     """
     from sempy_labs.tom import connect_semantic_model
 

--- a/src/sempy_labs/semantic_model/_Fix_WholeNumberFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_WholeNumberFormat.py
@@ -10,7 +10,8 @@ def fix_whole_number_format(
     scan_only: bool = False,
 ):
     """
-    Sets format string to #,0 on integer-typed measures without a format string.
+    Sets format string to #,0 on integer-typed measures (DataType=Int64) that
+    have neither a static FormatString nor a dynamic FormatStringDefinition.
 
     Parameters
     ----------
@@ -29,13 +30,15 @@ def fix_whole_number_format(
 
         for table in tom.model.Tables:
             for m in table.Measures:
+                # Only target measures that actually return an integer
+                if m.DataType != TOM.DataType.Int64:
+                    continue
+                # Skip measures with a dynamic format string
+                if m.FormatStringDefinition is not None:
+                    continue
+                # Skip measures that already have a static format string
                 fmt = str(m.FormatString) if m.FormatString else ""
                 if fmt.strip():
-                    continue  # already has a format
-                # Check if the measure likely returns an integer
-                # (heuristic: name doesn't suggest % or ratio)
-                name_lower = m.Name.lower()
-                if any(k in name_lower for k in ("%", "percent", "pct", "ratio", "rate")):
                     continue
                 if scan_only:
                     print(f"  Would fix: [{m.Name}] → #,0")
@@ -43,8 +46,7 @@ def fix_whole_number_format(
                     m.FormatString = "#,0"
                     print(f"  Fixed: [{m.Name}] → #,0")
                 fixed += 1
-        if not scan_only and fixed > 0:
-            tom.model.SaveChanges()
+        # Context manager (TOMWrapper.close) persists changes; no SaveChanges() needed.
 
     action = "Would fix" if scan_only else "Fixed"
     print(f"  {action} {fixed} measure(s).")

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -13,3 +13,6 @@ __all__ = [
     "make_discoverable",
     "enable_query_caching",
 ]
+
+from ._Fix_WholeNumberFormat import fix_whole_number_format
+__all__ += ["fix_whole_number_format"]


### PR DESCRIPTION
Adds a sempy_labs fixer `fix_whole_number_format()` that set #,0 format on integer measures.

Adds **one** source file (`src/sempy_labs/semantic_model/_Fix_WholeNumberFormat.py`) plus one re-export line in the matching `__init__.py`. No other files touched, no shared helpers, no dependency on any other PR.

**Part of the PBI Fixer contribution.** Tracking issue: #1185
