### PR TITLE
[pbi-fixer] Add fix_do_not_summarize: set SummarizeBy=None on numeric columns

### DIFF
--- a/src/sempy_labs/semantic_model/_Fix_DoNotSummarize.py
+++ b/src/sempy_labs/semantic_model/_Fix_DoNotSummarize.py
@@ -1,0 +1,54 @@
+# Fix "Do not summarize numeric columns" — standalone BPA fixer.
+# Sets SummarizeBy to None on all numeric data columns.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_do_not_summarize(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets SummarizeBy to None on numeric data columns.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        import Microsoft.AnalysisServices.Tabular as TOM
+
+        for table in tom.model.Tables:
+            for col in table.Columns:
+                if col.Type != TOM.ColumnType.Data:
+                    continue
+                if col.DataType not in (TOM.DataType.Int64, TOM.DataType.Double, TOM.DataType.Decimal):
+                    continue
+                if str(col.SummarizeBy) == "None":
+                    continue
+                if scan_only:
+                    print(f"  Would fix: '{table.Name}'[{col.Name}] SummarizeBy={col.SummarizeBy} → None")
+                else:
+                    col.SummarizeBy = TOM.AggregateFunction.Default  # None
+                    try:
+                        col.SummarizeBy = getattr(TOM.AggregateFunction, "None_", TOM.AggregateFunction.Default)
+                    except Exception:
+                        pass
+                    print(f"  Fixed: '{table.Name}'[{col.Name}] → SummarizeBy=None")
+                fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_DoNotSummarize.py
+++ b/src/sempy_labs/semantic_model/_Fix_DoNotSummarize.py
@@ -8,21 +8,26 @@ from sempy._utils._log import log
 
 @log
 def fix_do_not_summarize(
-    dataset: str,
+    dataset: str | UUID,
     workspace: Optional[str | UUID] = None,
     scan_only: bool = False,
-):
+) -> int:
     """
     Sets SummarizeBy to None on numeric data columns.
 
     Parameters
     ----------
-    dataset : str
-        Name of the semantic model.
+    dataset : str | UUID
+        Name or ID of the semantic model.
     workspace : str | uuid.UUID, default=None
         The Fabric workspace name or ID.
     scan_only : bool, default=False
         If True, only reports what would be fixed without making changes.
+
+    Returns
+    -------
+    int
+        Number of items fixed.
     """
     from sempy_labs.tom import connect_semantic_model
 
@@ -41,11 +46,13 @@ def fix_do_not_summarize(
                 if scan_only:
                     print(f"  Would fix: '{table.Name}'[{col.Name}] SummarizeBy={col.SummarizeBy} → None")
                 else:
-                    col.SummarizeBy = TOM.AggregateFunction.Default  # None
-                    try:
-                        col.SummarizeBy = getattr(TOM.AggregateFunction, "None_", TOM.AggregateFunction.Default)
-                    except Exception:
-                        pass
+                    none_attr = getattr(TOM.AggregateFunction, "None_", None)
+                    if none_attr is None:
+                        raise RuntimeError(
+                            f"Could not set SummarizeBy=None on column \"{col.Name}\": "
+                            f"TOM.AggregateFunction.None_ is not available in this environment."
+                        )
+                    col.SummarizeBy = none_attr
                     print(f"  Fixed: '{table.Name}'[{col.Name}] → SummarizeBy=None")
                 fixed += 1
 

--- a/src/sempy_labs/semantic_model/_Fix_DoNotSummarize.py
+++ b/src/sempy_labs/semantic_model/_Fix_DoNotSummarize.py
@@ -3,8 +3,10 @@
 
 from typing import Optional
 from uuid import UUID
+from sempy._utils._log import log
 
 
+@log
 def fix_do_not_summarize(
     dataset: str,
     workspace: Optional[str | UUID] = None,
@@ -46,8 +48,6 @@ def fix_do_not_summarize(
                         pass
                     print(f"  Fixed: '{table.Name}'[{col.Name}] → SummarizeBy=None")
                 fixed += 1
-        if not scan_only and fixed > 0:
-            tom.model.SaveChanges()
 
     action = "Would fix" if scan_only else "Fixed"
     print(f"  {action} {fixed} column(s).")

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -13,3 +13,6 @@ __all__ = [
     "make_discoverable",
     "enable_query_caching",
 ]
+
+from ._Fix_DoNotSummarize import fix_do_not_summarize
+__all__ += ["fix_do_not_summarize"]

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -6,13 +6,12 @@ from ._copilot import (
 from ._caching import (
     enable_query_caching,
 )
+from ._Fix_DoNotSummarize import fix_do_not_summarize
 
 __all__ = [
     "approved_for_copilot",
     "set_endorsement",
     "make_discoverable",
     "enable_query_caching",
+    "fix_do_not_summarize",
 ]
-
-from ._Fix_DoNotSummarize import fix_do_not_summarize
-__all__ += ["fix_do_not_summarize"]


### PR DESCRIPTION
Adds a sempy_labs fixer `fix_do_not_summarize()` that set SummarizeBy=None on key/ID numeric columns.

Adds **one** source file (`src/sempy_labs/semantic_model/_Fix_DoNotSummarize.py`) plus one re-export line in the matching `__init__.py`. No other files touched, no shared helpers, no dependency on any other PR.

**Part of the PBI Fixer contribution.** Tracking issue: #1185
