### PR TITLE
[pbi-fixer] Add fix_hide_foreign_keys: hide foreign-key columns

### DIFF
--- a/src/sempy_labs/semantic_model/_Fix_HideForeignKeys.py
+++ b/src/sempy_labs/semantic_model/_Fix_HideForeignKeys.py
@@ -1,0 +1,48 @@
+# Fix hidden foreign keys — standalone BPA fixer.
+# Hides columns that are used as foreign keys in relationships.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_hide_foreign_keys(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Hides columns that participate as foreign keys (From side) in relationships.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        # Collect foreign key columns (From side of relationships)
+        fk_cols = set()
+        for rel in tom.model.Relationships:
+            fk_cols.add((str(rel.FromTable.Name), str(rel.FromColumn.Name)))
+
+        for table in tom.model.Tables:
+            for col in table.Columns:
+                if (table.Name, col.Name) in fk_cols and not col.IsHidden:
+                    if scan_only:
+                        print(f"  Would hide: '{table.Name}'[{col.Name}]")
+                    else:
+                        col.IsHidden = True
+                        print(f"  Hidden: '{table.Name}'[{col.Name}]")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would hide" if scan_only else "Hidden"
+    print(f"  {action} {fixed} foreign key column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_HideForeignKeys.py
+++ b/src/sempy_labs/semantic_model/_Fix_HideForeignKeys.py
@@ -8,21 +8,26 @@ from sempy._utils._log import log
 
 @log
 def fix_hide_foreign_keys(
-    dataset: str,
+    dataset: str | UUID,
     workspace: Optional[str | UUID] = None,
     scan_only: bool = False,
-):
+) -> int:
     """
     Hides columns that participate as foreign keys (From side) in relationships.
 
     Parameters
     ----------
-    dataset : str
-        Name of the semantic model.
+    dataset : str | UUID
+        Name or ID of the semantic model.
     workspace : str | uuid.UUID, default=None
         The Fabric workspace name or ID.
     scan_only : bool, default=False
         If True, only reports what would be fixed without making changes.
+
+    Returns
+    -------
+    int
+        Number of items fixed.
     """
     from sempy_labs.tom import connect_semantic_model
 

--- a/src/sempy_labs/semantic_model/_Fix_HideForeignKeys.py
+++ b/src/sempy_labs/semantic_model/_Fix_HideForeignKeys.py
@@ -3,8 +3,10 @@
 
 from typing import Optional
 from uuid import UUID
+from sempy._utils._log import log
 
 
+@log
 def fix_hide_foreign_keys(
     dataset: str,
     workspace: Optional[str | UUID] = None,
@@ -40,8 +42,6 @@ def fix_hide_foreign_keys(
                         col.IsHidden = True
                         print(f"  Hidden: '{table.Name}'[{col.Name}]")
                     fixed += 1
-        if not scan_only and fixed > 0:
-            tom.model.SaveChanges()
 
     action = "Would hide" if scan_only else "Hidden"
     print(f"  {action} {fixed} foreign key column(s).")

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -13,3 +13,6 @@ __all__ = [
     "make_discoverable",
     "enable_query_caching",
 ]
+
+from ._Fix_HideForeignKeys import fix_hide_foreign_keys
+__all__ += ["fix_hide_foreign_keys"]

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -6,13 +6,12 @@ from ._copilot import (
 from ._caching import (
     enable_query_caching,
 )
+from ._Fix_HideForeignKeys import fix_hide_foreign_keys
 
 __all__ = [
     "approved_for_copilot",
     "set_endorsement",
     "make_discoverable",
     "enable_query_caching",
+    "fix_hide_foreign_keys",
 ]
-
-from ._Fix_HideForeignKeys import fix_hide_foreign_keys
-__all__ += ["fix_hide_foreign_keys"]


### PR DESCRIPTION
Adds a sempy_labs fixer `fix_hide_foreign_keys()` that hide foreign-key columns.

Adds **one** source file (`src/sempy_labs/semantic_model/_Fix_HideForeignKeys.py`) plus one re-export line in the matching `__init__.py`. No other files touched, no shared helpers, no dependency on any other PR.

**Part of the PBI Fixer contribution.** Tracking issue: #1185
