### PR TITLE
[pbi-fixer] Add fix_mark_primary_keys: set IsKey=True on detected primary keys

### DIFF
--- a/src/sempy_labs/semantic_model/_Fix_MarkPrimaryKeys.py
+++ b/src/sempy_labs/semantic_model/_Fix_MarkPrimaryKeys.py
@@ -1,0 +1,51 @@
+# Fix "Mark primary keys" — standalone BPA fixer.
+# Sets IsKey=True on the To-side column of relationships.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_mark_primary_keys(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets IsKey=True on columns that are the primary key side (To) of relationships.
+
+    Only applies when the column is not already a key and the table has no existing key.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for rel in tom.model.Relationships:
+            to_col = rel.ToColumn
+            to_table = rel.ToTable
+            if to_col.IsKey:
+                continue
+            # Check if table already has a key column
+            has_key = any(c.IsKey for c in to_table.Columns)
+            if has_key:
+                continue
+            if scan_only:
+                print(f"  Would mark: '{to_table.Name}'[{to_col.Name}] as primary key")
+            else:
+                to_col.IsKey = True
+                print(f"  Marked: '{to_table.Name}'[{to_col.Name}] as primary key")
+            fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would mark" if scan_only else "Marked"
+    print(f"  {action} {fixed} primary key column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_MarkPrimaryKeys.py
+++ b/src/sempy_labs/semantic_model/_Fix_MarkPrimaryKeys.py
@@ -8,10 +8,10 @@ from sempy._utils._log import log
 
 @log
 def fix_mark_primary_keys(
-    dataset: str,
+    dataset: str | UUID,
     workspace: Optional[str | UUID] = None,
     scan_only: bool = False,
-):
+) -> int:
     """
     Sets IsKey=True on columns that are the primary key side (To) of relationships.
 
@@ -19,12 +19,17 @@ def fix_mark_primary_keys(
 
     Parameters
     ----------
-    dataset : str
-        Name of the semantic model.
+    dataset : str | UUID
+        Name or ID of the semantic model.
     workspace : str | uuid.UUID, default=None
         The Fabric workspace name or ID.
     scan_only : bool, default=False
         If True, only reports what would be fixed without making changes.
+
+    Returns
+    -------
+    int
+        Number of items fixed.
     """
     from sempy_labs.tom import connect_semantic_model
 

--- a/src/sempy_labs/semantic_model/_Fix_MarkPrimaryKeys.py
+++ b/src/sempy_labs/semantic_model/_Fix_MarkPrimaryKeys.py
@@ -3,8 +3,10 @@
 
 from typing import Optional
 from uuid import UUID
+from sempy._utils._log import log
 
 
+@log
 def fix_mark_primary_keys(
     dataset: str,
     workspace: Optional[str | UUID] = None,
@@ -43,8 +45,6 @@ def fix_mark_primary_keys(
                 to_col.IsKey = True
                 print(f"  Marked: '{to_table.Name}'[{to_col.Name}] as primary key")
             fixed += 1
-        if not scan_only and fixed > 0:
-            tom.model.SaveChanges()
 
     action = "Would mark" if scan_only else "Marked"
     print(f"  {action} {fixed} primary key column(s).")

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -13,3 +13,6 @@ __all__ = [
     "make_discoverable",
     "enable_query_caching",
 ]
+
+from ._Fix_MarkPrimaryKeys import fix_mark_primary_keys
+__all__ += ["fix_mark_primary_keys"]

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -6,13 +6,12 @@ from ._copilot import (
 from ._caching import (
     enable_query_caching,
 )
+from ._Fix_MarkPrimaryKeys import fix_mark_primary_keys
 
 __all__ = [
     "approved_for_copilot",
     "set_endorsement",
     "make_discoverable",
     "enable_query_caching",
+    "fix_mark_primary_keys",
 ]
-
-from ._Fix_MarkPrimaryKeys import fix_mark_primary_keys
-__all__ += ["fix_mark_primary_keys"]


### PR DESCRIPTION
Adds a sempy_labs fixer `fix_mark_primary_keys()` that set IsKey=True on detected primary keys.

Adds **one** source file (`src/sempy_labs/semantic_model/_Fix_MarkPrimaryKeys.py`) plus one re-export line in the matching `__init__.py`. No other files touched, no shared helpers, no dependency on any other PR.

**Part of the PBI Fixer contribution.** Tracking issue: #1185
