### PR TITLE
[pbi-fixer] Add fix_isavailable_in_mdx: set IsAvailableInMDX=False on hidden columns

### DIFF
--- a/src/sempy_labs/semantic_model/_Fix_IsAvailableInMdx.py
+++ b/src/sempy_labs/semantic_model/_Fix_IsAvailableInMdx.py
@@ -1,0 +1,43 @@
+# Fix IsAvailableInMDX — standalone BPA fixer.
+# Sets IsAvailableInMDX to False on non-attribute columns.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_isavailable_in_mdx(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets IsAvailableInMDX to False on columns where it is True.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            for col in table.Columns:
+                if getattr(col, "IsAvailableInMDX", False):
+                    if scan_only:
+                        print(f"  Would fix: '{table.Name}'[{col.Name}] IsAvailableInMDX → False")
+                    else:
+                        col.IsAvailableInMDX = False
+                        print(f"  Fixed: '{table.Name}'[{col.Name}] IsAvailableInMDX → False")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_IsAvailableInMdx.py
+++ b/src/sempy_labs/semantic_model/_Fix_IsAvailableInMdx.py
@@ -3,8 +3,10 @@
 
 from typing import Optional
 from uuid import UUID
+from sempy._utils._log import log
 
 
+@log
 def fix_isavailable_in_mdx(
     dataset: str,
     workspace: Optional[str | UUID] = None,
@@ -35,8 +37,6 @@ def fix_isavailable_in_mdx(
                         col.IsAvailableInMDX = False
                         print(f"  Fixed: '{table.Name}'[{col.Name}] IsAvailableInMDX → False")
                     fixed += 1
-        if not scan_only and fixed > 0:
-            tom.model.SaveChanges()
 
     action = "Would fix" if scan_only else "Fixed"
     print(f"  {action} {fixed} column(s).")

--- a/src/sempy_labs/semantic_model/_Fix_IsAvailableInMdx.py
+++ b/src/sempy_labs/semantic_model/_Fix_IsAvailableInMdx.py
@@ -8,21 +8,26 @@ from sempy._utils._log import log
 
 @log
 def fix_isavailable_in_mdx(
-    dataset: str,
+    dataset: str | UUID,
     workspace: Optional[str | UUID] = None,
     scan_only: bool = False,
-):
+) -> int:
     """
     Sets IsAvailableInMDX to False on columns where it is True.
 
     Parameters
     ----------
-    dataset : str
-        Name of the semantic model.
+    dataset : str | UUID
+        Name or ID of the semantic model.
     workspace : str | uuid.UUID, default=None
         The Fabric workspace name or ID.
     scan_only : bool, default=False
         If True, only reports what would be fixed without making changes.
+
+    Returns
+    -------
+    int
+        Number of items fixed.
     """
     from sempy_labs.tom import connect_semantic_model
 

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -6,13 +6,12 @@ from ._copilot import (
 from ._caching import (
     enable_query_caching,
 )
+from ._Fix_IsAvailableInMdx import fix_isavailable_in_mdx
 
 __all__ = [
     "approved_for_copilot",
     "set_endorsement",
     "make_discoverable",
     "enable_query_caching",
+    "fix_isavailable_in_mdx",
 ]
-
-from ._Fix_IsAvailableInMdx import fix_isavailable_in_mdx
-__all__ += ["fix_isavailable_in_mdx"]

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -13,3 +13,6 @@ __all__ = [
     "make_discoverable",
     "enable_query_caching",
 ]
+
+from ._Fix_IsAvailableInMdx import fix_isavailable_in_mdx
+__all__ += ["fix_isavailable_in_mdx"]


### PR DESCRIPTION
Adds a sempy_labs fixer `fix_isavailable_in_mdx()` that set IsAvailableInMDX=False on hidden columns.

Adds **one** source file (`src/sempy_labs/semantic_model/_Fix_IsAvailableInMdx.py`) plus one re-export line in the matching `__init__.py`. No other files touched, no shared helpers, no dependency on any other PR.

**Part of the PBI Fixer contribution.** Tracking issue: #1185
