### PR TITLE
[pbi-fixer] Add fix_isavailable_in_mdx_true: set IsAvailableInMDX=True on visible attribute columns

### DIFF
--- a/src/sempy_labs/semantic_model/_Fix_IsAvailableInMdxTrue.py
+++ b/src/sempy_labs/semantic_model/_Fix_IsAvailableInMdxTrue.py
@@ -1,0 +1,57 @@
+# Fix "Set IsAvailableInMdx to true on necessary columns" — standalone BPA fixer.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_isavailable_in_mdx_true(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets IsAvailableInMDX to True on key/attribute columns that incorrectly have it False.
+
+    Targets columns that are: (a) used as keys in relationships (To side), or
+    (b) used in hierarchies, or (c) marked as IsKey.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        # Collect columns that should have IsAvailableInMDX = True
+        needed = set()
+        for rel in tom.model.Relationships:
+            needed.add((str(rel.ToTable.Name), str(rel.ToColumn.Name)))
+        for table in tom.model.Tables:
+            for h in table.Hierarchies:
+                for lvl in h.Levels:
+                    needed.add((str(table.Name), str(lvl.Column.Name)))
+            for col in table.Columns:
+                if col.IsKey:
+                    needed.add((str(table.Name), str(col.Name)))
+
+        for table in tom.model.Tables:
+            for col in table.Columns:
+                if (table.Name, col.Name) in needed and not col.IsAvailableInMDX:
+                    if scan_only:
+                        print(f"  Would fix: '{table.Name}'[{col.Name}] IsAvailableInMDX → True")
+                    else:
+                        col.IsAvailableInMDX = True
+                        print(f"  Fixed: '{table.Name}'[{col.Name}] IsAvailableInMDX → True")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} column(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_IsAvailableInMdxTrue.py
+++ b/src/sempy_labs/semantic_model/_Fix_IsAvailableInMdxTrue.py
@@ -2,8 +2,10 @@
 
 from typing import Optional
 from uuid import UUID
+from sempy._utils._log import log
 
 
+@log
 def fix_isavailable_in_mdx_true(
     dataset: str,
     workspace: Optional[str | UUID] = None,
@@ -49,8 +51,6 @@ def fix_isavailable_in_mdx_true(
                         col.IsAvailableInMDX = True
                         print(f"  Fixed: '{table.Name}'[{col.Name}] IsAvailableInMDX → True")
                     fixed += 1
-        if not scan_only and fixed > 0:
-            tom.model.SaveChanges()
 
     action = "Would fix" if scan_only else "Fixed"
     print(f"  {action} {fixed} column(s).")

--- a/src/sempy_labs/semantic_model/_Fix_IsAvailableInMdxTrue.py
+++ b/src/sempy_labs/semantic_model/_Fix_IsAvailableInMdxTrue.py
@@ -7,10 +7,10 @@ from sempy._utils._log import log
 
 @log
 def fix_isavailable_in_mdx_true(
-    dataset: str,
+    dataset: str | UUID,
     workspace: Optional[str | UUID] = None,
     scan_only: bool = False,
-):
+) -> int:
     """
     Sets IsAvailableInMDX to True on key/attribute columns that incorrectly have it False.
 
@@ -19,12 +19,17 @@ def fix_isavailable_in_mdx_true(
 
     Parameters
     ----------
-    dataset : str
-        Name of the semantic model.
+    dataset : str | UUID
+        Name or ID of the semantic model.
     workspace : str | uuid.UUID, default=None
         The Fabric workspace name or ID.
     scan_only : bool, default=False
         If True, only reports what would be fixed without making changes.
+
+    Returns
+    -------
+    int
+        Number of items fixed.
     """
     from sempy_labs.tom import connect_semantic_model
 

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -6,13 +6,12 @@ from ._copilot import (
 from ._caching import (
     enable_query_caching,
 )
+from ._Fix_IsAvailableInMdxTrue import fix_isavailable_in_mdx_true
 
 __all__ = [
     "approved_for_copilot",
     "set_endorsement",
     "make_discoverable",
     "enable_query_caching",
+    "fix_isavailable_in_mdx_true",
 ]
-
-from ._Fix_IsAvailableInMdxTrue import fix_isavailable_in_mdx_true
-__all__ += ["fix_isavailable_in_mdx_true"]

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -13,3 +13,6 @@ __all__ = [
     "make_discoverable",
     "enable_query_caching",
 ]
+
+from ._Fix_IsAvailableInMdxTrue import fix_isavailable_in_mdx_true
+__all__ += ["fix_isavailable_in_mdx_true"]


### PR DESCRIPTION
Adds a sempy_labs fixer `fix_isavailable_in_mdx_true()` that set IsAvailableInMDX=True on visible attribute columns.

Adds **one** source file (`src/sempy_labs/semantic_model/_Fix_IsAvailableInMdxTrue.py`) plus one re-export line in the matching `__init__.py`. No other files touched, no shared helpers, no dependency on any other PR.

**Part of the PBI Fixer contribution.** Tracking issue: #1185
