### PR TITLE
[pbi-fixer] Add fix_measure_descriptions: set measure descriptions from DAX expression

### DIFF
--- a/src/sempy_labs/semantic_model/_Fix_MeasureDescriptions.py
+++ b/src/sempy_labs/semantic_model/_Fix_MeasureDescriptions.py
@@ -1,0 +1,46 @@
+# Fix measure descriptions — standalone BPA fixer.
+# Sets measure description to its DAX expression when description is empty.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_measure_descriptions(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets the description of visible measures (that have no description) to their DAX expression.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            for m in table.Measures:
+                if not m.IsHidden and (not m.Description or str(m.Description).strip() == ""):
+                    expr = str(m.Expression) if m.Expression else ""
+                    if not expr:
+                        continue
+                    if scan_only:
+                        print(f"  Would fix: [{m.Name}] — set description to DAX expression")
+                    else:
+                        m.Description = expr
+                        print(f"  Fixed: [{m.Name}] — description set to DAX expression")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} measure description(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_MeasureDescriptions.py
+++ b/src/sempy_labs/semantic_model/_Fix_MeasureDescriptions.py
@@ -8,21 +8,26 @@ from sempy._utils._log import log
 
 @log
 def fix_measure_descriptions(
-    dataset: str,
+    dataset: str | UUID,
     workspace: Optional[str | UUID] = None,
     scan_only: bool = False,
-):
+) -> int:
     """
     Sets the description of visible measures (that have no description) to their DAX expression.
 
     Parameters
     ----------
-    dataset : str
-        Name of the semantic model.
+    dataset : str | UUID
+        Name or ID of the semantic model.
     workspace : str | uuid.UUID, default=None
         The Fabric workspace name or ID.
     scan_only : bool, default=False
         If True, only reports what would be fixed without making changes.
+
+    Returns
+    -------
+    int
+        Number of items fixed.
     """
     from sempy_labs.tom import connect_semantic_model
 

--- a/src/sempy_labs/semantic_model/_Fix_MeasureDescriptions.py
+++ b/src/sempy_labs/semantic_model/_Fix_MeasureDescriptions.py
@@ -3,8 +3,10 @@
 
 from typing import Optional
 from uuid import UUID
+from sempy._utils._log import log
 
 
+@log
 def fix_measure_descriptions(
     dataset: str,
     workspace: Optional[str | UUID] = None,
@@ -38,8 +40,6 @@ def fix_measure_descriptions(
                         m.Description = expr
                         print(f"  Fixed: [{m.Name}] — description set to DAX expression")
                     fixed += 1
-        if not scan_only and fixed > 0:
-            tom.model.SaveChanges()
 
     action = "Would fix" if scan_only else "Fixed"
     print(f"  {action} {fixed} measure description(s).")

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -13,3 +13,6 @@ __all__ = [
     "make_discoverable",
     "enable_query_caching",
 ]
+
+from ._Fix_MeasureDescriptions import fix_measure_descriptions
+__all__ += ["fix_measure_descriptions"]

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -6,13 +6,12 @@ from ._copilot import (
 from ._caching import (
     enable_query_caching,
 )
+from ._Fix_MeasureDescriptions import fix_measure_descriptions
 
 __all__ = [
     "approved_for_copilot",
     "set_endorsement",
     "make_discoverable",
     "enable_query_caching",
+    "fix_measure_descriptions",
 ]
-
-from ._Fix_MeasureDescriptions import fix_measure_descriptions
-__all__ += ["fix_measure_descriptions"]


### PR DESCRIPTION
Adds a sempy_labs fixer `fix_measure_descriptions()` that set measure descriptions from DAX expression.

Adds **one** source file (`src/sempy_labs/semantic_model/_Fix_MeasureDescriptions.py`) plus one re-export line in the matching `__init__.py`. No other files touched, no shared helpers, no dependency on any other PR.

**Part of the PBI Fixer contribution.** Tracking issue: #1185
