### PR TITLE
[pbi-fixer] Add fix_avoid_adding_zero: remove '0+' prefix from measure expressions

### DIFF
--- a/src/sempy_labs/semantic_model/_Fix_AvoidAdding0.py
+++ b/src/sempy_labs/semantic_model/_Fix_AvoidAdding0.py
@@ -1,0 +1,48 @@
+# Fix "Avoid adding 0 to a measure" — standalone BPA fixer.
+# Strips "0+" or "0 +" prefix from measure expressions.
+
+from typing import Optional
+from uuid import UUID
+import re
+
+
+def fix_avoid_adding_zero(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Removes '0+' or '0 +' prefix from measure expressions.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            for m in table.Measures:
+                expr = str(m.Expression) if m.Expression else ""
+                stripped = expr.replace(" ", "")
+                if stripped.startswith("0+"):
+                    new_expr = re.sub(r'^\s*0\s*\+\s*', '', expr)
+                    if new_expr != expr:
+                        if scan_only:
+                            print(f"  Would fix: [{m.Name}] — remove '0+' prefix")
+                        else:
+                            m.Expression = new_expr
+                            print(f"  Fixed: [{m.Name}] — removed '0+' prefix")
+                        fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} measure(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_AvoidAdding0.py
+++ b/src/sempy_labs/semantic_model/_Fix_AvoidAdding0.py
@@ -9,21 +9,26 @@ from sempy._utils._log import log
 
 @log
 def fix_avoid_adding_zero(
-    dataset: str,
+    dataset: str | UUID,
     workspace: Optional[str | UUID] = None,
     scan_only: bool = False,
-):
+) -> int:
     """
     Removes '0+' or '0 +' prefix from measure expressions.
 
     Parameters
     ----------
-    dataset : str
-        Name of the semantic model.
+    dataset : str | UUID
+        Name or ID of the semantic model.
     workspace : str | uuid.UUID, default=None
         The Fabric workspace name or ID.
     scan_only : bool, default=False
         If True, only reports what would be fixed without making changes.
+
+    Returns
+    -------
+    int
+        Number of items fixed.
     """
     from sempy_labs.tom import connect_semantic_model
 

--- a/src/sempy_labs/semantic_model/_Fix_AvoidAdding0.py
+++ b/src/sempy_labs/semantic_model/_Fix_AvoidAdding0.py
@@ -4,8 +4,10 @@
 from typing import Optional
 from uuid import UUID
 import re
+from sempy._utils._log import log
 
 
+@log
 def fix_avoid_adding_zero(
     dataset: str,
     workspace: Optional[str | UUID] = None,
@@ -40,8 +42,6 @@ def fix_avoid_adding_zero(
                             m.Expression = new_expr
                             print(f"  Fixed: [{m.Name}] — removed '0+' prefix")
                         fixed += 1
-        if not scan_only and fixed > 0:
-            tom.model.SaveChanges()
 
     action = "Would fix" if scan_only else "Fixed"
     print(f"  {action} {fixed} measure(s).")

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -13,3 +13,6 @@ __all__ = [
     "make_discoverable",
     "enable_query_caching",
 ]
+
+from ._Fix_AvoidAdding0 import fix_avoid_adding_zero
+__all__ += ["fix_avoid_adding_zero"]

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -6,13 +6,12 @@ from ._copilot import (
 from ._caching import (
     enable_query_caching,
 )
+from ._Fix_AvoidAdding0 import fix_avoid_adding_zero
 
 __all__ = [
     "approved_for_copilot",
     "set_endorsement",
     "make_discoverable",
     "enable_query_caching",
+    "fix_avoid_adding_zero",
 ]
-
-from ._Fix_AvoidAdding0 import fix_avoid_adding_zero
-__all__ += ["fix_avoid_adding_zero"]


### PR DESCRIPTION
Adds a sempy_labs fixer `fix_avoid_adding_zero()` that remove '0+' prefix from measure expressions.

Adds **one** source file (`src/sempy_labs/semantic_model/_Fix_AvoidAdding0.py`) plus one re-export line in the matching `__init__.py`. No other files touched, no shared helpers, no dependency on any other PR.

**Part of the PBI Fixer contribution.** Tracking issue: #1185
