### PR TITLE
[pbi-fixer] Add fix_use_divide_function: replace simple / operators with DIVIDE() in measures

### DIFF
--- a/src/sempy_labs/semantic_model/_Fix_UseDivideFunction.py
+++ b/src/sempy_labs/semantic_model/_Fix_UseDivideFunction.py
@@ -1,0 +1,67 @@
+# Fix "Use the DIVIDE function for division" — standalone BPA fixer.
+# Replaces simple A / B patterns in measure expressions with DIVIDE(A, B).
+
+from typing import Optional
+from uuid import UUID
+import re
+
+
+def fix_use_divide_function(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Replaces simple division operators (/) in measure expressions with DIVIDE().
+
+    Only fixes patterns like `] / ` or `) / ` (single-level divisions).
+    Nested or complex cases are skipped.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    # Pattern: captures `<expr>] / <expr>` or `<expr>) / <expr>`
+    # We match: (something ending in ] or )) followed by whitespace / whitespace (something)
+    _div_pattern = re.compile(
+        r'(\[[^\]]+\]|\([^()]*\))\s*/\s*(\[[^\]]+\]|\([^()]*\))',
+        re.IGNORECASE,
+    )
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            for m in table.Measures:
+                expr = str(m.Expression) if m.Expression else ""
+                if "/" not in expr:
+                    continue
+                # Skip if already using DIVIDE predominantly
+                if expr.upper().count("DIVIDE") > expr.count("/"):
+                    continue
+                # Simple replacement: ] / [ or ] / ( or ) / [
+                new_expr = re.sub(
+                    r'((?:\]\s*|\)\s*))\s*/\s*((?:\s*\[|\s*[A-Za-z]))',
+                    lambda match: f'DIVIDE({match.group(0).replace("/", ",", 1)})',
+                    expr,
+                    count=0,
+                )
+                if new_expr != expr:
+                    if scan_only:
+                        print(f"  Would fix: [{m.Name}]")
+                    else:
+                        m.Expression = new_expr
+                        print(f"  Fixed: [{m.Name}]")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} measure(s) with division operator.")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_UseDivideFunction.py
+++ b/src/sempy_labs/semantic_model/_Fix_UseDivideFunction.py
@@ -4,8 +4,10 @@
 from typing import Optional
 from uuid import UUID
 import re
+from sempy._utils._log import log
 
 
+@log
 def fix_use_divide_function(
     dataset: str,
     workspace: Optional[str | UUID] = None,
@@ -59,8 +61,6 @@ def fix_use_divide_function(
                         m.Expression = new_expr
                         print(f"  Fixed: [{m.Name}]")
                     fixed += 1
-        if not scan_only and fixed > 0:
-            tom.model.SaveChanges()
 
     action = "Would fix" if scan_only else "Fixed"
     print(f"  {action} {fixed} measure(s) with division operator.")

--- a/src/sempy_labs/semantic_model/_Fix_UseDivideFunction.py
+++ b/src/sempy_labs/semantic_model/_Fix_UseDivideFunction.py
@@ -9,10 +9,10 @@ from sempy._utils._log import log
 
 @log
 def fix_use_divide_function(
-    dataset: str,
+    dataset: str | UUID,
     workspace: Optional[str | UUID] = None,
     scan_only: bool = False,
-):
+) -> int:
     """
     Replaces simple division operators (/) in measure expressions with DIVIDE().
 
@@ -21,12 +21,17 @@ def fix_use_divide_function(
 
     Parameters
     ----------
-    dataset : str
-        Name of the semantic model.
+    dataset : str | UUID
+        Name or ID of the semantic model.
     workspace : str | uuid.UUID, default=None
         The Fabric workspace name or ID.
     scan_only : bool, default=False
         If True, only reports what would be fixed without making changes.
+
+    Returns
+    -------
+    int
+        Number of items fixed.
     """
     from sempy_labs.tom import connect_semantic_model
 
@@ -48,10 +53,7 @@ def fix_use_divide_function(
                 if expr.upper().count("DIVIDE") > expr.count("/"):
                     continue
                 # Simple replacement: ] / [ or ] / ( or ) / [
-                new_expr = re.sub(
-                    r'((?:\]\s*|\)\s*))\s*/\s*((?:\s*\[|\s*[A-Za-z]))',
-                    lambda match: f'DIVIDE({match.group(0).replace("/", ",", 1)})',
-                    expr,
+                new_expr = re.sub(r"\[([^\]]+)\]\s*/\s*\[([^\]]+)\]", r"DIVIDE([\1], [\2])", expr,
                     count=0,
                 )
                 if new_expr != expr:

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -6,13 +6,12 @@ from ._copilot import (
 from ._caching import (
     enable_query_caching,
 )
+from ._Fix_UseDivideFunction import fix_use_divide_function
 
 __all__ = [
     "approved_for_copilot",
     "set_endorsement",
     "make_discoverable",
     "enable_query_caching",
+    "fix_use_divide_function",
 ]
-
-from ._Fix_UseDivideFunction import fix_use_divide_function
-__all__ += ["fix_use_divide_function"]

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -13,3 +13,6 @@ __all__ = [
     "make_discoverable",
     "enable_query_caching",
 ]
+
+from ._Fix_UseDivideFunction import fix_use_divide_function
+__all__ += ["fix_use_divide_function"]


### PR DESCRIPTION
Adds a sempy_labs fixer `fix_use_divide_function()` that replace simple / operators with DIVIDE() in measures.

Adds **one** source file (`src/sempy_labs/semantic_model/_Fix_UseDivideFunction.py`) plus one re-export line in the matching `__init__.py`. No other files touched, no shared helpers, no dependency on any other PR.

**Part of the PBI Fixer contribution.** Tracking issue: #1185
