### PR TITLE
[pbi-fixer] Add fix_measure_format: set #,0 format on measures with no format string

### DIFF
--- a/src/sempy_labs/semantic_model/_Fix_MeasureFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_MeasureFormat.py
@@ -1,0 +1,44 @@
+# Fix measure format — standalone BPA fixer.
+# Sets format string for measures without a format to #,0.
+
+from typing import Optional
+from uuid import UUID
+
+
+def fix_measure_format(
+    dataset: str,
+    workspace: Optional[str | UUID] = None,
+    scan_only: bool = False,
+):
+    """
+    Sets the format string of measures that have no format string to #,0.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the semantic model.
+    workspace : str | uuid.UUID, default=None
+        The Fabric workspace name or ID.
+    scan_only : bool, default=False
+        If True, only reports what would be fixed without making changes.
+    """
+    from sempy_labs.tom import connect_semantic_model
+
+    fixed = 0
+    with connect_semantic_model(dataset=dataset, readonly=scan_only, workspace=workspace) as tom:
+        for table in tom.model.Tables:
+            for m in table.Measures:
+                fmt = str(m.FormatString) if m.FormatString else ""
+                if not fmt.strip():
+                    if scan_only:
+                        print(f"  Would fix: [{m.Name}] → #,0")
+                    else:
+                        m.FormatString = "#,0"
+                        print(f"  Fixed: [{m.Name}] → #,0")
+                    fixed += 1
+        if not scan_only and fixed > 0:
+            tom.model.SaveChanges()
+
+    action = "Would fix" if scan_only else "Fixed"
+    print(f"  {action} {fixed} measure format(s).")
+    return fixed

--- a/src/sempy_labs/semantic_model/_Fix_MeasureFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_MeasureFormat.py
@@ -3,8 +3,10 @@
 
 from typing import Optional
 from uuid import UUID
+from sempy._utils._log import log
 
 
+@log
 def fix_measure_format(
     dataset: str,
     workspace: Optional[str | UUID] = None,
@@ -36,8 +38,6 @@ def fix_measure_format(
                         m.FormatString = "#,0"
                         print(f"  Fixed: [{m.Name}] → #,0")
                     fixed += 1
-        if not scan_only and fixed > 0:
-            tom.model.SaveChanges()
 
     action = "Would fix" if scan_only else "Fixed"
     print(f"  {action} {fixed} measure format(s).")

--- a/src/sempy_labs/semantic_model/_Fix_MeasureFormat.py
+++ b/src/sempy_labs/semantic_model/_Fix_MeasureFormat.py
@@ -8,21 +8,26 @@ from sempy._utils._log import log
 
 @log
 def fix_measure_format(
-    dataset: str,
+    dataset: str | UUID,
     workspace: Optional[str | UUID] = None,
     scan_only: bool = False,
-):
+) -> int:
     """
     Sets the format string of measures that have no format string to #,0.
 
     Parameters
     ----------
-    dataset : str
-        Name of the semantic model.
+    dataset : str | UUID
+        Name or ID of the semantic model.
     workspace : str | uuid.UUID, default=None
         The Fabric workspace name or ID.
     scan_only : bool, default=False
         If True, only reports what would be fixed without making changes.
+
+    Returns
+    -------
+    int
+        Number of items fixed.
     """
     from sempy_labs.tom import connect_semantic_model
 

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -6,13 +6,12 @@ from ._copilot import (
 from ._caching import (
     enable_query_caching,
 )
+from ._Fix_MeasureFormat import fix_measure_format
 
 __all__ = [
     "approved_for_copilot",
     "set_endorsement",
     "make_discoverable",
     "enable_query_caching",
+    "fix_measure_format",
 ]
-
-from ._Fix_MeasureFormat import fix_measure_format
-__all__ += ["fix_measure_format"]

--- a/src/sempy_labs/semantic_model/__init__.py
+++ b/src/sempy_labs/semantic_model/__init__.py
@@ -13,3 +13,6 @@ __all__ = [
     "make_discoverable",
     "enable_query_caching",
 ]
+
+from ._Fix_MeasureFormat import fix_measure_format
+__all__ += ["fix_measure_format"]


### PR DESCRIPTION
Adds a sempy_labs fixer `fix_measure_format()` that set #,0 format on measures with no format string.

Adds **one** source file (`src/sempy_labs/semantic_model/_Fix_MeasureFormat.py`) plus one re-export line in the matching `__init__.py`. No other files touched, no shared helpers, no dependency on any other PR.

**Part of the PBI Fixer contribution.** Tracking issue: #1185
