### PR TITLE
Add CreateOrOverwrite and OverwriteOnly options for to shortcut_conflict_policy in lakehouse.create_shortcut_onelake function

### DIFF
--- a/src/sempy_labs/lakehouse/_shortcuts.py
+++ b/src/sempy_labs/lakehouse/_shortcuts.py
@@ -15,6 +15,13 @@ import sempy_labs._icons as icons
 from uuid import UUID
 from sempy.fabric.exceptions import FabricHTTPException
 
+SHORTCUT_CONFLICT_POLICIES = [
+    "Abort",
+    "GenerateUniqueName",
+    "CreateOrOverwrite",
+    "OverwriteOnly",
+]
+
 
 @log
 def create_shortcut_onelake(
@@ -149,9 +156,9 @@ def create_shortcut_onelake(
     url = f"/v1/workspaces/{destination_workspace_id}/items/{destination_lakehouse_id}/shortcuts"
 
     if shortcut_conflict_policy:
-        if shortcut_conflict_policy not in ["Abort", "GenerateUniqueName", "CreateOrOverwrite", "OverwriteOnly"]:
+        if shortcut_conflict_policy not in SHORTCUT_CONFLICT_POLICIES:
             raise ValueError(
-                f"{icons.red_dot} The 'shortcut_conflict_policy' parameter must be one of the following strings: ('Abort', 'GenerateUniqueName', 'CreateOrOverwrite', 'OverwriteOnly')."
+                f"{icons.red_dot} The 'shortcut_conflict_policy' parameter must be one of the following strings: {tuple(SHORTCUT_CONFLICT_POLICIES)}."
             )
         url += f"?shortcutConflictPolicy={shortcut_conflict_policy}"
 

--- a/src/sempy_labs/lakehouse/_shortcuts.py
+++ b/src/sempy_labs/lakehouse/_shortcuts.py
@@ -15,12 +15,12 @@ import sempy_labs._icons as icons
 from uuid import UUID
 from sempy.fabric.exceptions import FabricHTTPException
 
-SHORTCUT_CONFLICT_POLICIES = [
+SHORTCUT_CONFLICT_POLICIES = (
     "Abort",
     "GenerateUniqueName",
     "CreateOrOverwrite",
     "OverwriteOnly",
-]
+)
 
 
 @log
@@ -158,7 +158,7 @@ def create_shortcut_onelake(
     if shortcut_conflict_policy:
         if shortcut_conflict_policy not in SHORTCUT_CONFLICT_POLICIES:
             raise ValueError(
-                f"{icons.red_dot} The 'shortcut_conflict_policy' parameter must be one of the following strings: {tuple(SHORTCUT_CONFLICT_POLICIES)}."
+                f"{icons.red_dot} The 'shortcut_conflict_policy' parameter must be one of the following strings: {SHORTCUT_CONFLICT_POLICIES}."
             )
         url += f"?shortcutConflictPolicy={shortcut_conflict_policy}"
 

--- a/src/sempy_labs/lakehouse/_shortcuts.py
+++ b/src/sempy_labs/lakehouse/_shortcuts.py
@@ -149,9 +149,9 @@ def create_shortcut_onelake(
     url = f"/v1/workspaces/{destination_workspace_id}/items/{destination_lakehouse_id}/shortcuts"
 
     if shortcut_conflict_policy:
-        if shortcut_conflict_policy not in ["Abort", "GenerateUniqueName"]:
+        if shortcut_conflict_policy not in ["Abort", "GenerateUniqueName", "CreateOrOverwrite", "OverwriteOnly"]:
             raise ValueError(
-                f"{icons.red_dot} The 'shortcut_conflict_policy' parameter must be either 'Abort' or 'GenerateUniqueName'."
+                f"{icons.red_dot} The 'shortcut_conflict_policy' parameter must be one of the following strings: ('Abort', 'GenerateUniqueName', 'CreateOrOverwrite', 'OverwriteOnly')."
             )
         url += f"?shortcutConflictPolicy={shortcut_conflict_policy}"
 


### PR DESCRIPTION
Extends create_shortcut_onelake to accept additional shortcut conflict policies and updates the validation error message accordingly.

Changes:
•	Allow CreateOrOverwrite and OverwriteOnly values for shortcut_conflict_policy.
•	Update the ValueError message to reflect the expanded set of supported policy strings.
