### PR TITLE
Update `_format_dax` to use the new DAX Formatter API endpoint

### DIFF
--- a/src/sempy_labs/_daxformatter.py
+++ b/src/sempy_labs/_daxformatter.py
@@ -18,7 +18,7 @@ def _format_dax(
     # Add variable assignment to each expression
     expressions = [f"x :={item}" for item in expressions]
 
-    url = "https://daxformatter.azurewebsites.net/api/daxformatter/daxtextformatmulti"
+    url = "https://api.daxformatter.com/api/daxtextformatmulti"
 
     payload = {
         "Dax": expressions,
@@ -33,7 +33,7 @@ def _format_dax(
         "Accept-Encoding": "gzip,deflate",
         "Accept-Language": "en-US,en;q=0.8",
         "Content-Type": "application/json; charset=UTF-8",
-        "Host": "daxformatter.azurewebsites.net",
+        "Host": "api.daxformatter.com",
         "Expect": "100-continue",
         "Connection": "Keep-Alive",
         "CallerApp": lib_name,

--- a/src/sempy_labs/_daxformatter.py
+++ b/src/sempy_labs/_daxformatter.py
@@ -26,6 +26,8 @@ def _format_dax(
         "SkipSpaceAfterFunctionName": skip_space_after_function_name,
         "ListSeparator": ",",
         "DecimalSeparator": ".",
+        "CallerApp": lib_name,
+        "CallerVersion": lib_version,
     }
 
     headers = {
@@ -36,8 +38,6 @@ def _format_dax(
         "Host": "api.daxformatter.com",
         "Expect": "100-continue",
         "Connection": "Keep-Alive",
-        "CallerApp": lib_name,
-        "CallerVersion": lib_version,
     }
 
     response = requests.post(url, json=payload, headers=headers)


### PR DESCRIPTION
This pull request updates `_format_dax` to use the new API endpoint. The DaxFormatter service migrated from `daxformatter.azurewebsites.net` to the new official domain `api.daxformatter.com`, with an updated path — as documented in the upstream change: [sql-bi/DaxFormatter#23](https://github.com/sql-bi/DaxFormatter/pull/23).

Changes:

- **API URL**: https://daxformatter.azurewebsites.net/api/daxformatter/daxtextformatmulti → https://api.daxformatter.com/api/daxtextformatmulti` (both domain and path changed — the `/daxformatter/` segment was removed from the path) (df6085066fa8fe32a3aa2dbb9559de8de012b0de)
- **`CallerApp` / `CallerVersion`**: moved from HTTP headers into the JSON request body, aligning with the reference C# implementation in [`DaxFormatterRequest.cs`](https://github.com/sql-bi/DaxFormatter/blob/main/src/Dax.Formatter/Models/DaxFormatterRequest.cs) where these are serialized as body properties, not headers. (f353df357c0e92317a4eab60902ccc63e2e4edd3)