### PR TITLE
Fix broken unit math in get_semantic_model_size()

### DIFF
--- a/src/sempy_labs/_generate_semantic_model.py
+++ b/src/sempy_labs/_generate_semantic_model.py
@@ -614,7 +614,7 @@ def get_semantic_model_definition(
 @log
 def get_semantic_model_size(
     dataset: str | UUID, workspace: Optional[str | UUID] = None
-):
+) -> int:
     """
     Gets size of the semantic model in bytes.
 
@@ -651,14 +651,5 @@ def get_semantic_model_size(
     dict_size = dict["[DICTIONARY_SIZE]"].sum()
     used_size = used_size["[USED_SIZE]"].sum()
     model_size = dict_size + used_size
-    # Calculate proper bytes size by dividing by 1024 and multiplying by 1000 - per 1000
-    if model_size >= 10**9:
-        result = model_size / (1024**3) * 10**9
-    elif model_size >= 10**6:
-        result = model_size / (1024**2) * 10**6
-    elif model_size >= 10**3:
-        result = model_size / (1024) * 10**3
-    else:
-        result = model_size
 
-    return float(result)
+    return int(model_size)

--- a/tests/test_get_semantic_model_size.py
+++ b/tests/test_get_semantic_model_size.py
@@ -1,0 +1,50 @@
+import pandas as pd
+
+import sempy_labs._generate_semantic_model as generate_semantic_model
+from sempy_labs import get_semantic_model_size
+
+
+def _mock_evaluate_dax_factory(dictionary_size_values, used_size_values):
+    def _mock_evaluate_dax(dataset, workspace, dax_string):
+        if "DICTIONARY_SIZE" in dax_string:
+            return pd.DataFrame({"[DICTIONARY_SIZE]": dictionary_size_values})
+        return pd.DataFrame({"[USED_SIZE]": used_size_values})
+
+    return _mock_evaluate_dax
+
+
+def test_get_semantic_model_size_returns_raw_byte_sum(monkeypatch):
+    """The result should be the plain sum of dictionary and used sizes,
+    with no unit rescaling, matching the documented "size in bytes"."""
+    monkeypatch.setattr(
+        generate_semantic_model.fabric,
+        "evaluate_dax",
+        _mock_evaluate_dax_factory([500], [500]),
+    )
+
+    result = get_semantic_model_size(dataset="test-dataset")
+
+    assert result == 1000
+    assert isinstance(result, int)
+
+
+def test_get_semantic_model_size_is_monotonic(monkeypatch):
+    """A larger contributing size should never produce a smaller result -
+    the previous KiB/KB rescaling broke this for values crossing 1024."""
+    monkeypatch.setattr(
+        generate_semantic_model.fabric,
+        "evaluate_dax",
+        _mock_evaluate_dax_factory([499], [500]),
+    )
+    smaller = get_semantic_model_size(dataset="test-dataset")
+
+    monkeypatch.setattr(
+        generate_semantic_model.fabric,
+        "evaluate_dax",
+        _mock_evaluate_dax_factory([500], [500]),
+    )
+    larger = get_semantic_model_size(dataset="test-dataset")
+
+    assert smaller == 999
+    assert larger == 1000
+    assert larger > smaller


### PR DESCRIPTION
Closes #1284.

## Bug

`get_semantic_model_size()` sums `DICTIONARY_SIZE` and `USED_SIZE` (both already in bytes, from `INFO.STORAGETABLECOLUMNS()` / `INFO.STORAGETABLECOLUMNSEGMENTS()`), then ran that sum through a rescale step keyed off which size bracket it landed in:

```python
if model_size >= 10**9:
    result = model_size / (1024**3) * 10**9
elif model_size >= 10**6:
    result = model_size / (1024**2) * 10**6
elif model_size >= 10**3:
    result = model_size / (1024) * 10**3
else:
    result = model_size
return float(result)
```

As pointed out in the issue, this breaks monotonicity right at each bracket boundary:

```python
>>> old_buggy(999)
999.0
>>> old_buggy(1000)   # more bytes in, smaller number out
976.5625
```

It also returns a `float`, even though the docstring documents `int` / "size in bytes".

## Fix

Removed the rescaling block entirely and return the raw byte sum as an `int`:

```python
dict_size = dict["[DICTIONARY_SIZE]"].sum()
used_size = used_size["[USED_SIZE]"].sum()
model_size = dict_size + used_size

return int(model_size)
```

Also added a `-> int` return annotation to match the docstring.

## Testing

Added `tests/test_get_semantic_model_size.py`, following the same `monkeypatch.setattr(module.fabric, "evaluate_dax", ...)` pattern already used in `tests/test_dax.py`:

- `test_get_semantic_model_size_returns_raw_byte_sum` — 500 + 500 → `1000` (`int`), no rescaling.
- `test_get_semantic_model_size_is_monotonic` — reproduces the exact regression from the issue: 499+500 → 999, 500+500 → 1000, and asserts `1000 > 999` (this would fail against the old code, since 500+500 previously produced 976.5625).

Ran locally:
- `pytest -s tests/` — 7 passed (5 pre-existing + 2 new), no regressions.
- `black --check` / `flake8` on both changed files — clean (confirmed the only `black`/`flake8` deltas elsewhere in the file are pre-existing and untouched by this change).