### PR TITLE
Add Mac setup instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,21 +279,21 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 10. Run the following code in the terminal to ensure a virtual environment exists.
 
 For Windows:
-```python
+```cli
 python -m venv venv
 ```
 For Mac:
-```python
+```cli
 python3 -m venv venv
 ```
 11. Run the following code in the terminal to activate the virtual environment.
 
 For Windows:
-```python
+```cli
 .\venv\Scripts\Activate.ps1
 ```
 For Mac:
-```python
+```cli
 source venv/bin/activate
 ```
 12. Run the following code in the terminal to install the build module.

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 8. When prompted to open the cloned repository, click 'Open'.
 9. Open the integrated terminal (View -> Terminal).
 10. Run the following code in the terminal to ensure a virtual environment exists.
+
 For Windows:
 ```python
 python -m venv venv
@@ -286,6 +287,7 @@ For Mac:
 python3 -m venv venv
 ```
 11. Run the following code in the terminal to activate the virtual environment.
+
 For Windows:
 ```python
 .\venv\Scripts\Activate.ps1

--- a/README.md
+++ b/README.md
@@ -277,12 +277,22 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 8. When prompted to open the cloned repository, click 'Open'.
 9. Open the integrated terminal (View -> Terminal).
 10. Run the following code in the terminal to ensure a virtual environment exists.
+For Windows:
 ```python
 python -m venv venv
 ```
+For Mac:
+```python
+python3 -m venv venv
+```
 11. Run the following code in the terminal to activate the virtual environment.
+For Windows:
 ```python
 .\venv\Scripts\Activate.ps1
+```
+For Mac:
+```python
+source venv/bin/activate
 ```
 12. Run the following code in the terminal to install the build module.
 ```


### PR DESCRIPTION
Adds macOS-equivalent commands alongside the existing Windows-only setup steps (venv creation, activation).

**Why:** 
I hit several friction points following the guide on Mac — this should save future Mac contributors the same trial and error.

**Tested:** 
Ran through fork → clone → venv → activation → branch creation end-to-end on macOS.

**Remark:** 
Once the venv is activated, python3 isn't needed — python resolves correctly inside the environment. So the other Python commands were left as-is.