### PR TITLE
Fixed Direct Lake schema comparison bug

### DIFF
--- a/src/sempy_labs/directlake/_directlake_schema_compare.py
+++ b/src/sempy_labs/directlake/_directlake_schema_compare.py
@@ -76,6 +76,9 @@ def direct_lake_schema_compare(
                     )
                 else:
                     for c in p.Parent.Columns:
+                        if c.Type not in (TOM.ColumnType.Data, TOM.ColumnType.CalculatedTableColumn):
+                            # Columns of type Calculated and RowNumber are not sourced from external sources and therefore they do not contain "SourceColumn" property. So we skip them in the comparison.
+                            continue
                         col_name = c.Name
                         source_col = c.SourceColumn
                         df_lake_filt = df_lake[

--- a/src/sempy_labs/directlake/_directlake_schema_sync.py
+++ b/src/sempy_labs/directlake/_directlake_schema_sync.py
@@ -81,6 +81,9 @@ def direct_lake_schema_sync(
     ) as tom:
         # Check if the columns in the semantic model exist in the lakehouse
         for c in tom.all_columns():
+            if c.Type not in (TOM.ColumnType.Data, TOM.ColumnType.CalculatedTableColumn):
+                # Columns of type Calculated and RowNumber are not sourced from external sources and therefore they do not contain "SourceColumn" property. So we skip them in the comparison.
+                continue
             column_name = c.Name
             table_name = c.Parent.Name
             partition_name = next(p.Name for p in c.Table.Partitions)
@@ -130,7 +133,9 @@ def direct_lake_schema_sync(
 
                 if not any(
                     c.SourceColumn == source_column and c.Parent.Name == table_name
-                    for c in tom.all_columns()
+                    for c in tom.all_columns() if c.Type in (TOM.ColumnType.Data, TOM.ColumnType.CalculatedTableColumn)
+                    # Columns of type Calculated and RowNumber are not sourced from external sources and therefore they do not contain "SourceColumn" property.
+                    # We make sure to exclude them from Lakehouse <> Semantic Model comparison.
                 ):
                     rows_to_add.append(
                         {


### PR DESCRIPTION
**Describe the bug**
Two functions - `direct_lake_schema_compare` and `direct_lake_schema_sync` - raise an `AttributeError` when run against a Direct Lake semantic model that contains internal or non-data columns.

`direct_lake_schema_compare` fails when any Direct Lake table contains an internal `RowNumber` column (e.g. `RowNumber-XXXXX`). These columns are automatically added by the Analysis Services server and do not have a `SourceColumn` property.
`direct_lake_schema_sync` fails when the model contains a Calculated Table with at least one Calculated Column, and that Calculated Table's name does not sort last alphabetically among all model tables.
Both failures stem from accessing `c.SourceColumn` on column types that do not expose this property (`RowNumber`, `Calculated`).

This issue occurs only when the following `any()` function iterates across the entire model and finds the Calculated Column:
```python
if not any(
   c.SourceColumn == source_column and c.Parent.Name == table_name
   for c in tom.all_columns()
)
```

**To Reproduce**
Steps to reproduce the behavior:

1. Open a Fabric Lakehouse SQL Endpoint.
2. Create a new Semantic Model and select at least 2 tables.
3. In the Semantic Model, rename one table so it sorts last alphabetically (e.g. prefix it with `Z`).
4. Create a Calculated Table (e.g. `_measures = Row("Value", BLANK())`).
5. Add a Calculated Column to that table (e.g. `column_1 = 0.995`).
6. In a Fabric Notebook, run:
```python
import sempy_labs as labs
labs.direct_lake_schema_compare(dataset="<your model>", workspace="<your workspace>")
labs.direct_lake_schema_sync(dataset="<your model>", workspace="<your workspace>", add_to_model=True)
````
7. Observe that `direct_lake_schema_sync` raises:
```
AttributeError: 'CalculatedColumn' object has no attribute 'SourceColumn'
```
**Expected behavior**
Both functions should silently skip columns that are not sourced from an external data source (i.e. RowNumber and Calculated column types) and complete without error.

**Screenshots**

<img width="997" height="186" alt="Image" src="https://github.com/user-attachments/assets/c5e9532c-92d3-40f5-8e6f-5b2d7e5ccc02" />

<img width="1306" height="183" alt="Image" src="https://github.com/user-attachments/assets/53feea7e-6f71-47ed-8535-f13ac6327437" />
