### PR TITLE
Fixed empty SQL Endpoint refresh failure

### DIFF
--- a/src/sempy_labs/sql_endpoint/_items.py
+++ b/src/sempy_labs/sql_endpoint/_items.py
@@ -171,7 +171,7 @@ def refresh_sql_endpoint_metadata(
         "Error Code": "string",
         "Error Message": "string",
     }
-    
+
     result_value = result.get("value", [])
 
     if result_value:

--- a/src/sempy_labs/sql_endpoint/_items.py
+++ b/src/sempy_labs/sql_endpoint/_items.py
@@ -171,9 +171,11 @@ def refresh_sql_endpoint_metadata(
         "Error Code": "string",
         "Error Message": "string",
     }
+    
+    result_value = result.get("value", [])
 
-    if result:
-        df = pd.json_normalize(result.get("value"))
+    if result_value:
+        df = pd.json_normalize(result_value)
 
         # Extract error code and message, set to None if no error
         df["Error Code"] = df.get("error.errorCode", None)


### PR DESCRIPTION
**Describe the bug**
`refresh_sql_endpoint_metadata` raises a `KeyError` when called on a Lakehouse whose SQL endpoint contains no tables. The API still returns a response with an empty `"value"` list (`{"value": []}`), which is not treated as an empty result - causing the column reordering step to fail.

**To Reproduce**
Steps to reproduce the behavior:

1. Create a Lakehouse with no tables
2. Call `sempy_labs.refresh_sql_endpoint_metadata(item='<lakehouse_name>', type='Lakehouse', workspace='<workspace_name>')`
3. Observe a `KeyError: "['Table Name', 'Status', 'Start Time', 'End Time', 'Last Successful Sync Time'] not in index"`

**Expected behavior**
The function should complete successfully and return an empty DataFrame, printing a warning that there are no tables to refresh.

**Screenshots**

<img width="1308" height="225" alt="Image" src="https://github.com/user-attachments/assets/386ae5bd-11b6-462f-8865-d506da5da0c9" />


**Additional context**
This is particularly impactful for "landing" Lakehouses where tables may not exist at all times. If a pipeline calls `refresh_sql_endpoint_metadata` and the Lakehouse happens to be empty at that moment, the pipeline fails with a KeyError. The current workaround is to wrap the call in a try/except KeyError block on the caller's side.

_P.S. The handling of this already exists with if/else statement, however because the API response is non-empty - the else statement is not reached._

This closes #1313 
