### PR TITLE
Add expression_name parameter for keeping the source name as a part of the expression_name

### DIFF
--- a/src/sempy_labs/directlake/_update_directlake_model_lakehouse_connection.py
+++ b/src/sempy_labs/directlake/_update_directlake_model_lakehouse_connection.py
@@ -56,7 +56,7 @@ def update_direct_lake_model_connection(
     source_workspace: Optional[str | UUID] = None,
     use_sql_endpoint: bool = True,
     tables: Optional[str | List[str]] = None,
-	expression_name: Optional[str] = None,
+    expression_name: Optional[str] = None,
 ):
     """
     Remaps a Direct Lake semantic model's SQL Endpoint connection to a new lakehouse/warehouse.

--- a/src/sempy_labs/directlake/_update_directlake_model_lakehouse_connection.py
+++ b/src/sempy_labs/directlake/_update_directlake_model_lakehouse_connection.py
@@ -85,15 +85,6 @@ def update_direct_lake_model_connection(
         The name(s) of the table(s) to update in the Direct Lake semantic model.
         If None, all tables will be updated (if there is only one expression).
         If multiple tables are specified, they must be provided as a list.
-    expression_name : str
-        Optional explicit expression name containing the Lakehouse or Warehouse name, for the multi-source models. 
-        Example:        
-            update_direct_lake_model_connection(
-            ...
-            source=source_name,
-            ...
-            expression_name=f"DirectLake - {source_name}"
-            )
     """
     from sempy_labs.tom import connect_semantic_model
 
@@ -180,21 +171,18 @@ def update_direct_lake_model_connection(
                     if candidate not in existing_names:
                         return candidate
                     i += 1
-					
+                    
             expr_list = tom._extract_expression_list(shared_expression)
-			  
+              
             if expression_name:
                 expr_name = expression_name
-				
+                
             else:	
-                expr_name = next(
-					(name for name, exp in expression_dict.items() if exp == expr_list),
-					None,
-				)
-				
+                expr_name = next((name for name, exp in expression_dict.items() if exp == expr_list),None,)
+                
             if not expr_name: 
                 expr_name = generate_unique_name(expressions)
-				
+                
             if expr_name in expressions:
                 tom.model.Expressions[expr_name].Expression = shared_expression
             else:

--- a/src/sempy_labs/directlake/_update_directlake_model_lakehouse_connection.py
+++ b/src/sempy_labs/directlake/_update_directlake_model_lakehouse_connection.py
@@ -56,6 +56,7 @@ def update_direct_lake_model_connection(
     source_workspace: Optional[str | UUID] = None,
     use_sql_endpoint: bool = True,
     tables: Optional[str | List[str]] = None,
+	expression_name: Optional[str] = None,
 ):
     """
     Remaps a Direct Lake semantic model's SQL Endpoint connection to a new lakehouse/warehouse.
@@ -84,6 +85,15 @@ def update_direct_lake_model_connection(
         The name(s) of the table(s) to update in the Direct Lake semantic model.
         If None, all tables will be updated (if there is only one expression).
         If multiple tables are specified, they must be provided as a list.
+    expression_name : str
+        Optional explicit expression name containing the Lakehouse or Warehouse name, for the multi-source models. 
+        Example:        
+            update_direct_lake_model_connection(
+            ...
+            source=source_name,
+            ...
+            expression_name=f"DirectLake - {source_name}"
+            )
     """
     from sempy_labs.tom import connect_semantic_model
 
@@ -162,14 +172,7 @@ def update_direct_lake_model_connection(
             sempy.fabric._client._utils._init_analysis_services()
             import Microsoft.AnalysisServices.Tabular as TOM
 
-            expr_list = tom._extract_expression_list(shared_expression)
 
-            expr_name = next(
-                (name for name, exp in expression_dict.items() if exp == expr_list),
-                None,
-            )
-
-            # If the expression does not already exist, create it
             def generate_unique_name(existing_names):
                 i = 1
                 while True:
@@ -177,9 +180,24 @@ def update_direct_lake_model_connection(
                     if candidate not in existing_names:
                         return candidate
                     i += 1
-
-            if not expr_name:
+					
+            expr_list = tom._extract_expression_list(shared_expression)
+			  
+            if expression_name:
+                expr_name = expression_name
+				
+            else:	
+                expr_name = next(
+					(name for name, exp in expression_dict.items() if exp == expr_list),
+					None,
+				)
+				
+            if not expr_name: 
                 expr_name = generate_unique_name(expressions)
+				
+            if expr_name in expressions:
+                tom.model.Expressions[expr_name].Expression = shared_expression
+            else:
                 tom.add_expression(name=expr_name, expression=shared_expression)
 
             all_tables = [t.Name for t in tom.model.Tables]


### PR DESCRIPTION
Added an optional expression_name parameter to allow  idempotent updates for multi-source models